### PR TITLE
Simple helper to read out emailDomain

### DIFF
--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/User.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/User.scala
@@ -4,4 +4,6 @@ case class User(firstName: String, lastName: String, email: String, avatarUrl: O
   def toJson = {
     s"""{"firstName": "$firstName", "lastName": "$lastName", "email": "$email" ${avatarUrl.map( u => s""", "avatarUrl": "$u" """).getOrElse("")} }"""
   }
+
+  def emailDomain = email.split("@").last
 }


### PR DESCRIPTION
Makes it tidier to check the domain:

``` scala
  override def validateUser(authedUser: AuthenticatedUser): Boolean = {
    (authedUser.user.emailDomain == "guardian.co.uk") && authedUser.multiFactor
  }
```

vs the current:

``` scala
  override def validateUser(authedUser: AuthenticatedUser): Boolean = {
    (authedUser.user.email endsWith ("@guardian.co.uk")) && authedUser.multiFactor
  }
```
