### PR TITLE
Refactor Play implem to expose more helpers that can be reused

### DIFF
--- a/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -162,7 +162,7 @@ trait AuthActions extends PanDomainAuth {
   /**
    * Extract the authentication status from the request.
    */
-  def extractAuth[A](request: Request[A]): AuthenticationStatus = try {
+  def extractAuth(request: RequestHeader): AuthenticationStatus = try {
     readAuthenticatedUser(request) map { authedUser =>
       if (authedUser.isExpired) {
         Expired(authedUser)


### PR DESCRIPTION
Mainly split the auth status logic from the actions they trigger, so that the logic can be reused generically outside of the existing actions.
