### PR TITLE
Validation check update

### DIFF
--- a/pan-domain-auth-example/app/controllers/ExampleAuthActions.scala
+++ b/pan-domain-auth-example/app/controllers/ExampleAuthActions.scala
@@ -4,6 +4,7 @@ import com.amazonaws.auth.{BasicAWSCredentials, AWSCredentials}
 import com.amazonaws.regions.Region
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
+import play.api.Logger
 
 trait ExampleAuthActions extends AuthActions {
 
@@ -11,9 +12,11 @@ trait ExampleAuthActions extends AuthActions {
   lazy val config = play.api.Play.configuration
 
   override def validateUser(authedUser: AuthenticatedUser): Boolean = {
-    println(authedUser.toString)
+    Logger.info(s"validating user $authedUser")
     (authedUser.user.email endsWith ("@guardian.co.uk")) && authedUser.multiFactor
   }
+
+  override def cacheValidation = false
 
   override def authCallbackUrl: String = config.getString("host").get + "/oathCallback"
 

--- a/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -109,7 +109,7 @@ trait AuthActions extends PanDomainAuth {
           claimedAuth.copy(
             authenticatingSystem = system,
             authenticatedIn = Set(system),
-            multiFactor = existingAuth.multiFactor
+            multiFactor = checkMultifactor(claimedAuth)
           )
         }
         case None => {


### PR DESCRIPTION
updates the play implementation to check user validity every request.

the old behaviour (only checking validity once per system per google session) can be turned back on by overriding the cacheValidation setting to true.

Note this is not implemented in the core library so the flex (scalatra) implementation will need to be updated to behave similarly.