### PR TITLE
Extended expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,14 @@ Add the ```AuthAction``` or ```ApiAuthAction``` to any endpoints you with to req
   
 * ```ApiAuthAction``` is used for api ajax / xhr style requests and will not redirect to google for auth. This action will either process
   the action or return an error code that can be processed by your client javascript (see section on handling expired logins in a single
-  page webapp). The response codes are:
+  page webapp).
+
+  A grace period on expiry can be set by adding a ```apiGracePeriod```. This is useful for when browsers have third party cookies disabled
+  and reauthenticaiton solutions like [pandular](https://github.com/guardian/pandular) break due to cookies being blocked on ```window.open```
+  or ```iframe``` requests. During this period we are hopeful of the user refreshing or revisiting the application through a standard browser
+  request thus triggering off a reauthentication.
+
+  The response codes are:
   
     * **401** - user not authenticated - probably tricky to get this response as presumably the user has already loaded a page that would have
             logged them in

--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/AuthenticatedUser.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/AuthenticatedUser.scala
@@ -5,5 +5,5 @@ import java.util.Date
 case class AuthenticatedUser(user: User, authenticatingSystem: String, authenticatedIn: Set[String], expires: Long, multiFactor: Boolean) {
 
   def isExpired = expires < new Date().getTime
-  def hasExpiryExtension(extension: Long) = (expires + extension) > new Date().getTime
+  def isInGracePeriod(period: Long) = (expires + period) > new Date().getTime
 }

--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/AuthenticatedUser.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/AuthenticatedUser.scala
@@ -5,4 +5,5 @@ import java.util.Date
 case class AuthenticatedUser(user: User, authenticatingSystem: String, authenticatedIn: Set[String], expires: Long, multiFactor: Boolean) {
 
   def isExpired = expires < new Date().getTime
+  def hasExpiryExtension(extension: Long) = (expires + extension) < new Date().getTime
 }

--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/AuthenticatedUser.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/AuthenticatedUser.scala
@@ -5,5 +5,5 @@ import java.util.Date
 case class AuthenticatedUser(user: User, authenticatingSystem: String, authenticatedIn: Set[String], expires: Long, multiFactor: Boolean) {
 
   def isExpired = expires < new Date().getTime
-  def hasExpiryExtension(extension: Long) = (expires + extension) < new Date().getTime
+  def hasExpiryExtension(extension: Long) = (expires + extension) > new Date().getTime
 }

--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/PanDomainAuthSettings.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/PanDomainAuthSettings.scala
@@ -5,9 +5,7 @@ case class PanDomainAuthSettings(
   cookieName: String,
   googleAuthSettings: GoogleAuthSettings,
   google2FAGroupSettings: Option[Google2FAGroupSettings]
-) {
-
-}
+)
 
 case class GoogleAuthSettings(
   googleAuthClient: String,

--- a/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -38,7 +38,17 @@ trait AuthActions extends PanDomainAuth {
    */
   def cacheValidation: Boolean = false
 
+
+  /**
+   * Adding an expiry extension to `APIAuthAction`s allows for a delay between an applications authentication and their
+   * respective API XHR calls expiring.
+   *
+   * This is particularly useful for SPAs where users have third party cookies disabled.
+   *
+   * @return the amount of delay between App and API expiry in milliseconds
+   */
   def apiExpiryExtension: Long = 1.hour.toMillis
+
 
   /**
    * The auth callback url. This is where google will send the user after authentication. This action on this url should

--- a/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -43,11 +43,13 @@ trait AuthActions extends PanDomainAuth {
    * Adding an expiry extension to `APIAuthAction`s allows for a delay between an applications authentication and their
    * respective API XHR calls expiring.
    *
+   * By default this is 0 and thus disabled.
+   *
    * This is particularly useful for SPAs where users have third party cookies disabled.
    *
    * @return the amount of delay between App and API expiry in milliseconds
    */
-  def apiGracePeriod: Long = 1.hour.toMillis
+  def apiGracePeriod: Long = 0
 
 
   /**

--- a/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -49,7 +49,7 @@ trait AuthActions extends PanDomainAuth {
    *
    * @return the amount of delay between App and API expiry in milliseconds
    */
-  def apiGracePeriod: Long = 0
+  def apiGracePeriod: Long = 0 // ms
 
 
   /**


### PR DESCRIPTION
I've left it pretty simple for now hoping not to make a mess of it.

I also thought we could have this as a property that the apps using this could set, but the logic is always going to be "expire the API requests after the App" so I thought since all of that is accessible here, let's do it here.

I am not sure what needs to be changed in terms of versioning etc as I've never published scala stuff.