### PR TITLE
Refactor APIAuthAction to allow custom overriding of error results

### DIFF
--- a/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -5,11 +5,10 @@ import com.gu.pandomainauth.model.{AuthenticatedUser, User}
 import com.gu.pandomainauth.service.{Google2FAGroupChecker, GoogleAuthException, GoogleAuth, CookieUtils}
 import play.api.mvc.Results._
 import play.api.mvc._
-import play.api.{Application, Logger}
+import play.api.Logger
 import play.api.Play.current
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.DurationInt
 
 
 class UserRequest[A](val user: User, request: Request[A]) extends WrappedRequest[A](request)


### PR DESCRIPTION
Currenty APIAuthAction returns error responses with an empty body. :-1: 

Different consumers may want to provide different error responses based on their API semantics, so this decouples the `Result`s of error responses from the extra logic needed for each case.