### PR TITLE
Fix character encoding in new cookie

### DIFF
--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/CookieUtils.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/CookieUtils.scala
@@ -50,7 +50,7 @@ object CookieUtils {
       case CookieRegEx(data, sig) =>
         try {
           if (Crypto.verifySignature(Base64.decodeBase64(data.getBytes("UTF-8")), Base64.decodeBase64(sig.getBytes("UTF-8")), pubKeyStr)) {
-            deserializeAuthenticatedUser(new String(Base64.decodeBase64(data)))
+            deserializeAuthenticatedUser(new String(Base64.decodeBase64(data.getBytes("UTF-8"))))
           } else {
             throw new CookieSignatureInvalidException
           }

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/service/CookieUtilsTest.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/service/CookieUtilsTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.{FreeSpec, Matchers}
 class CookieUtilsTest extends FreeSpec with Matchers {
   import TestKeys._
 
-  val authUser = AuthenticatedUser(User("test", "user", "test.user@example.com", None), "testsuite", Set("testsuite", "another"), new Date().getTime + 86400, multiFactor = true)
+  val authUser = AuthenticatedUser(User("test", "üsér", "test.user@example.com", None), "testsuite", Set("testsuite", "another"), new Date().getTime + 86400, multiFactor = true)
 
   "generateCookieData" - {
     "generates a a base64-encoded 'data.signature' cookie value" in {


### PR DESCRIPTION
We no longer rely on the platform's default character encoding being correct.

(There was a missing `getBytes("UTF-8")` call in the CookieUtils)