### PR TITLE
Use credentialsProvider instead of awsCredentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,8 +351,8 @@ More examples and framework clients may be added in the future as they become av
 Access to the s3 bucket is controlled by overriding the `awsCredentials` and `awsRegion` options in the `PanDomainAuth` trait (or the
 `AuthActions` sub trait in the play implementation).
 
-* **awsCredentials** defaults to None - this means that the instance profile of your app running in EC2 will be used. You can configure access to the bucket
-in your cloud formation script. For apps that are not running in EC2 (such as developer environments) you can supply `BasicAWSCredentials` with a key and secret
+* **awsCredentialsProvider** defaults to DefaultAWSCredentialsProviderChain - this means that the instance profile of your app running in EC2 will be used. You can configure access to the bucket
+in your cloud formation script. For apps that are not running in EC2 (such as developer environments) you can supply `StaticCredentialsProvider(BasicAWSCredentials)` with a key and secret
 for a user that will grant access to the bucket.
 
 * **awsRegion** defaults to eu-west-1 - This is where the guardian runs the majority of it's aws estate so is a useful default for us.

--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/PanDomainAuth.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/PanDomainAuth.scala
@@ -1,6 +1,6 @@
 package com.gu.pandomainauth
 
-import com.amazonaws.auth.AWSCredentialsProviderChain
+import com.amazonaws.auth.{DefaultAWSCredentialsProviderChain, AWSCredentialsProvider}
 import com.amazonaws.regions.{Regions, Region}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -35,7 +35,7 @@ trait PanDomainAuth {
    * the AwsCredentials to access the configuration bucket, defaults to None so the instance credentials are used
    * @return
    */
-  def awsCredentials: Option[AWSCredentialsProviderChain] = None
+  def awsCredentialsProvider: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain()
 
   /**
    * the aws region the configuration bucket is in, defaults to eu-west-1 as that's where the guardian tends to run stuff
@@ -49,7 +49,7 @@ trait PanDomainAuth {
    */
   def proxyConfiguration: Option[ProxyConfiguration] = None
 
-  lazy val bucket = new S3Bucket(awsCredentials, awsRegion, proxyConfiguration)
+  lazy val bucket = new S3Bucket(awsCredentialsProvider, awsRegion, proxyConfiguration)
 
   lazy val settingsMap = bucket.readDomainSettings(domain)
   lazy val authSettings: Agent[PanDomainAuthSettings] = Agent(PanDomainAuthSettings(settingsMap))

--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/PanDomainAuth.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/PanDomainAuth.scala
@@ -1,6 +1,6 @@
 package com.gu.pandomainauth
 
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.amazonaws.regions.{Regions, Region}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -35,7 +35,7 @@ trait PanDomainAuth {
    * the AwsCredentials to access the configuration bucket, defaults to None so the instance credentials are used
    * @return
    */
-  def awsCredentials: Option[AWSCredentials] = None
+  def awsCredentials: Option[AWSCredentialsProviderChain] = None
 
   /**
    * the aws region the configuration bucket is in, defaults to eu-west-1 as that's where the guardian tends to run stuff

--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/service/S3Bucket.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/service/S3Bucket.scala
@@ -2,22 +2,20 @@ package com.gu.pandomainauth.service
 
 import java.util.Properties
 import com.amazonaws.ClientConfiguration
-import com.amazonaws.internal.StaticCredentialsProvider
 import com.amazonaws.regions.{Regions, Region}
 import com.gu.pandomainauth.PublicSettings
 
 import scala.collection.JavaConversions._
-import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.GetObjectRequest
 
 
 
-class S3Bucket(credentials: Option[AWSCredentials] = None, regionOption: Option[Region] = None, proxyConfiguration: Option[ProxyConfiguration] = None) {
+class S3Bucket(credentials: Option[AWSCredentialsProviderChain] = None, regionOption: Option[Region] = None, proxyConfiguration: Option[ProxyConfiguration] = None) {
 
-  val credentialsProvider = credentials.map(new StaticCredentialsProvider(_)).getOrElse(null)
-  val region = regionOption getOrElse(Region getRegion(Regions.EU_WEST_1))
-  val s3Client = region.createClient(classOf[AmazonS3Client], credentialsProvider, awsClientConfiguration)
+  val region = regionOption getOrElse (Region getRegion Regions.EU_WEST_1)
+  val s3Client = region.createClient(classOf[AmazonS3Client], credentials.orNull, awsClientConfiguration)
 
   val bucketName = PublicSettings.bucketName
 

--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/service/S3Bucket.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/service/S3Bucket.scala
@@ -6,16 +6,14 @@ import com.amazonaws.regions.{Regions, Region}
 import com.gu.pandomainauth.PublicSettings
 
 import scala.collection.JavaConversions._
-import com.amazonaws.auth.AWSCredentialsProviderChain
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.GetObjectRequest
 
-
-
-class S3Bucket(credentials: Option[AWSCredentialsProviderChain] = None, regionOption: Option[Region] = None, proxyConfiguration: Option[ProxyConfiguration] = None) {
+class S3Bucket(credentialsProvider: AWSCredentialsProvider, regionOption: Option[Region] = None, proxyConfiguration: Option[ProxyConfiguration] = None) {
 
   val region = regionOption getOrElse (Region getRegion Regions.EU_WEST_1)
-  val s3Client = region.createClient(classOf[AmazonS3Client], credentials.orNull, awsClientConfiguration)
+  val s3Client = region.createClient(classOf[AmazonS3Client], credentialsProvider, awsClientConfiguration)
 
   val bucketName = PublicSettings.bucketName
 

--- a/pan-domain-auth-example/app/controllers/ExampleAuthActions.scala
+++ b/pan-domain-auth-example/app/controllers/ExampleAuthActions.scala
@@ -1,6 +1,7 @@
 package controllers
 
-import com.amazonaws.auth.{BasicAWSCredentials, AWSCredentials}
+import com.amazonaws.auth.{AWSCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.internal.StaticCredentialsProvider
 import com.amazonaws.regions.Region
 import com.gu.pandomainauth.PanDomain
 import com.gu.pandomainauth.action.AuthActions
@@ -25,7 +26,7 @@ trait ExampleAuthActions extends AuthActions {
   lazy val awsSecretAccessKey: String = config.getString("aws.secret").get
   lazy val awsKeyId: String = config.getString("aws.keyId").get
 
-  override lazy val awsCredentials: Option[AWSCredentials] = Some(new BasicAWSCredentials(awsKeyId, awsSecretAccessKey))
+  override lazy val awsCredentialsProvider: AWSCredentialsProvider = new StaticCredentialsProvider(new BasicAWSCredentials(awsKeyId, awsSecretAccessKey))
 
   /**
    * the aws region the configuration bucket is in, defaults to eu-west-1 as that's where the guardian tends to run stuff


### PR DESCRIPTION
Otherwise when using temporary credentials the library will stop working after the credentials expire. This should fix that. 