### PR TITLE
Throw GoogleAuthException on 'anti forgery token did not match' error

### DIFF
--- a/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/service/GoogleAuth.scala
+++ b/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/service/GoogleAuth.scala
@@ -59,7 +59,7 @@ class GoogleAuth(config: GoogleAuthSettings, system: String, redirectUrl: String
   def validatedUserIdentity(expectedAntiForgeryToken: String)
                            (implicit request: RequestHeader, context: ExecutionContext, application: Application): Future[AuthenticatedUser] = {
     if (!request.queryString.getOrElse("state", Nil).contains(expectedAntiForgeryToken)) {
-      throw new IllegalArgumentException("The anti forgery token did not match")
+      throw new GoogleAuthException("The anti forgery token did not match")
     } else {
       discoveryDocument.flatMap { dd =>
         val code = request.queryString("code")


### PR DESCRIPTION
Change the type of error thrown when encountering a mismatching anti-forgery token, to match the errors thrown [in other cases when parsing the Google response](https://github.com/guardian/pan-domain-authentication/blob/e3f11de0fdb02a510176abd10b2b3492f6db3fa4/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/service/GoogleAuth.scala#L32-L44), in order to make it easier to match.

Alternatively I could amend our code to match `IllegalArgumentException` (though would have to do string matching into the error message which sounds wrong), if people think this shouldn't be the same type of exception.

Thoughts?

This is part of the work to reduce auth-related errors in the Grid. The idea would be to return a 400 whenever encountering any `GoogleAuthException`, hence encouraging the client to optionally retry the auth flow.