### PR TITLE
Specify dispatch-core library to resolve the incompatibilies issue

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,8 @@ object Dependencies {
   val playLibs_2_4_0 = Seq(
     "com.typesafe.play" %% "play" % "2.4.0" % "provided",
     "com.typesafe.play" %% "play-ws" % "2.4.0" % "provided",
-    "commons-codec" % "commons-codec" % "1.9"
+    "commons-codec" % "commons-codec" % "1.9",
+    "net.databinder.dispatch" %% "dispatch-core" % "0.11.3"
   )
 
   val googleDirectoryApiDependencies = Seq(


### PR DESCRIPTION
Play 2.4 has incompatibilities with Ning and dispatch libraries. This is problematic for users of PublicSettings (e.g https://github.com/guardian/login.gutools). This PR specifies the dispatch-core library which will resolve the issue.

See here for more details: https://github.com/AnormCypher/AnormCypher/issues/44

I've tested this change locally for the specific use case that login.gutools requires. @steppenwells @adamnfish please could you help me identify what other use cases I should test?