### PR TITLE
Read the asymmetric cookie rather than the legacy cookie

### DIFF
--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/PanDomainAuthSettings.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/PanDomainAuthSettings.scala
@@ -1,11 +1,11 @@
 package com.gu.pandomainauth.model
 
-import com.gu.pandomainauth.PublicSettings
+import com.gu.pandomainauth.{PrivateKey, PublicKey, PublicSettings, Secret}
 
 case class PanDomainAuthSettings(
-  secret: String,
-  publicKey: String,
-  privateKey: String,
+  secret: Secret,
+  publicKey: PublicKey,
+  privateKey: PrivateKey,
   googleAuthSettings: GoogleAuthSettings,
   google2FAGroupSettings: Option[Google2FAGroupSettings]
 ) {
@@ -43,6 +43,6 @@ object PanDomainAuthSettings{
       Google2FAGroupSettings(serviceAccountId, serviceAccountCert, adminUser, group)
     }
 
-    PanDomainAuthSettings(settingMap("secret"), settingMap("publicKey"), settingMap("privateKey"), googleAuthSettings, google2faSettings)
+    PanDomainAuthSettings(Secret(settingMap("secret")), PublicKey(settingMap("publicKey")), PrivateKey(settingMap("privateKey")), googleAuthSettings, google2faSettings)
   }
 }

--- a/pan-domain-auth-play_2-4-0/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-4-0/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -198,7 +198,7 @@ trait AuthActions extends PanDomainAuth {
    */
   def extractAuth(request: RequestHeader): AuthenticationStatus = {
     readCookie(request).map { cookie =>
-      PanDomain.authStatusWithLegacyCheck(cookie.value, settings.publicKey, settings.secret) match {
+      PanDomain.authStatus(cookie.value, settings.publicKey) match {
         case Expired(authedUser) if authedUser.isInGracePeriod(apiGracePeriod) =>
           GracePeriod(authedUser)
         case authStatus @ Authenticated(authedUser) =>

--- a/pan-domain-auth-play_2-4-0/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-4-0/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -119,17 +119,12 @@ trait AuthActions extends PanDomainAuth {
     GoogleAuth.validatedUserIdentity(token).map { claimedAuth =>
       val authedUserData = existingCookie match {
         case Some(c) => {
-          val existingAuth = try {
-            CookieUtils.parseCookieData(c.value, settings.publicKey)
-          } catch {
-            case NonFatal(e) =>
-              LegacyCookie.parseCookieData(c.value, settings.secret)
-          }
+          val existingAuth = CookieUtils.parseCookieData(c.value, settings.publicKey)
           Logger.debug("user re-authed, merging auth data")
 
           claimedAuth.copy(
             authenticatingSystem = system,
-            authenticatedIn = Set(system),
+            authenticatedIn = existingAuth.authenticatedIn ++ Set(system),
             multiFactor = checkMultifactor(claimedAuth)
           )
         }
@@ -154,11 +149,11 @@ trait AuthActions extends PanDomainAuth {
 
 
   def readAuthenticatedUser(request: RequestHeader): Option[AuthenticatedUser] = readCookie(request) map { cookie =>
-    CookieUtils.parseCookieData(cookie.value, settings.secret)
+    CookieUtils.parseCookieData(cookie.value, settings.publicKey)
   }
 
 
-  def readCookie(request: RequestHeader): Option[Cookie] = request.cookies.get(PublicSettings.cookieName)
+  def readCookie(request: RequestHeader): Option[Cookie] = request.cookies.get(PublicSettings.assymCookieName)
 
   def generateCookies(authedUser: AuthenticatedUser): List[Cookie] = List(
     Cookie(

--- a/pan-domain-auth-play_2-5/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-5/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -204,7 +204,7 @@ trait AuthActions extends PanDomainAuth {
    */
   def extractAuth(request: RequestHeader): AuthenticationStatus = {
     readCookie(request).map { cookie =>
-      PanDomain.authStatusWithLegacyCheck(cookie.value, settings.publicKey, settings.secret) match {
+      PanDomain.authStatus(cookie.value, settings.publicKey) match {
         case Expired(authedUser) if authedUser.isInGracePeriod(apiGracePeriod) =>
           GracePeriod(authedUser)
         case authStatus @ Authenticated(authedUser) =>

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PanDomain.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PanDomain.scala
@@ -8,7 +8,7 @@ object PanDomain {
   /**
    * Check the authentication status of the provided credentials by examining the signed cookie data.
    */
-  def authStatus(cookieData: String, publicKey: String, validateUser: AuthenticatedUser => Boolean = guardianValidation): AuthenticationStatus = {
+  def authStatus(cookieData: String, publicKey: PublicKey, validateUser: AuthenticatedUser => Boolean = guardianValidation): AuthenticationStatus = {
     try {
       val authedUser = CookieUtils.parseCookieData(cookieData, publicKey)
       checkStatus(authedUser, validateUser)
@@ -22,7 +22,7 @@ object PanDomain {
    * Cookie check that includes the legacy cookie. This is required during a period of transition
    * between the old cookie and the new assymetric one.
    */
-  def authStatusWithLegacyCheck(cookieData: String, publicKey: String, secret: String): AuthenticationStatus = {
+  def authStatusWithLegacyCheck(cookieData: String, publicKey: PublicKey, secret: Secret): AuthenticationStatus = {
     try {
       val authedUser = try {
         CookieUtils.parseCookieData(cookieData, publicKey)

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PanDomain.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PanDomain.scala
@@ -18,25 +18,6 @@ object PanDomain {
     }
   }
 
-  /**
-   * Cookie check that includes the legacy cookie. This is required during a period of transition
-   * between the old cookie and the new assymetric one.
-   */
-  def authStatusWithLegacyCheck(cookieData: String, publicKey: PublicKey, secret: Secret): AuthenticationStatus = {
-    try {
-      val authedUser = try {
-        CookieUtils.parseCookieData(cookieData, publicKey)
-      } catch {
-        case e: Exception =>
-          LegacyCookie.parseCookieData(cookieData, secret)
-      }
-      checkStatus(authedUser, _ => true)
-    } catch {
-      case e: Exception =>
-        InvalidCookie(e)
-    }
-  }
-
   private def checkStatus(authedUser: AuthenticatedUser, validateUser: AuthenticatedUser => Boolean = guardianValidation): AuthenticationStatus = {
     if (authedUser.isExpired) {
       Expired(authedUser)

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PublicSettings.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PublicSettings.scala
@@ -117,14 +117,14 @@ object PublicSettings {
   private[pandomainauth] def extractPublicKey(settings: Map[String, String]): Future[PublicKey] = {
     (for {
       rawKey <- settings.get("publicKey").toRight(PublicKeyNotFoundException).right
-      publicKey <- validateKey(rawKey).right
+      publicKey <- validateKey(PublicKey(rawKey)).right
     } yield publicKey) match {
       case Right(publicKey) => Future.successful(publicKey)
       case Left(err) => Future.failed(err)
     }
   }
-  private[pandomainauth] def validateKey(pubKey: String): Either[Throwable, PublicKey] = {
-    if ("[a-zA-Z0-9+/\n]+={0,3}".r.pattern.matcher(pubKey).matches) Right(PublicKey(pubKey))
+  private[pandomainauth] def validateKey(pubKey: PublicKey): Either[Throwable, PublicKey] = {
+    if ("[a-zA-Z0-9+/\n]+={0,3}".r.pattern.matcher(pubKey.key).matches) Right(pubKey)
     else Left(PublicKeyFormatException)
   }
 

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PublicSettings.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PublicSettings.scala
@@ -96,7 +96,7 @@ object PublicSettings {
    * @param client implicit dispatch.Http to use for fetching the key
    * @param ec     implicit execution context to use for fetching the key
    */
-  def getPublicKey(domain: String)(implicit client: Http, ec: ExecutionContext): Future[String] = {
+  def getPublicKey(domain: String)(implicit client: Http, ec: ExecutionContext): Future[PublicKey] = {
     getPublicSettings(domain) flatMap extractPublicKey
   }
 
@@ -114,7 +114,7 @@ object PublicSettings {
       case Left(err) =>
         Future.failed(new PublicSettingsAcquisitionException(err))
     }
-  private[pandomainauth] def extractPublicKey(settings: Map[String, String]): Future[String] = {
+  private[pandomainauth] def extractPublicKey(settings: Map[String, String]): Future[PublicKey] = {
     (for {
       rawKey <- settings.get("publicKey").toRight(PublicKeyNotFoundException).right
       publicKey <- validateKey(rawKey).right
@@ -123,8 +123,8 @@ object PublicSettings {
       case Left(err) => Future.failed(err)
     }
   }
-  private[pandomainauth] def validateKey(pubKey: String): Either[Throwable, String] = {
-    if ("[a-zA-Z0-9+/\n]+={0,3}".r.pattern.matcher(pubKey).matches) Right(pubKey)
+  private[pandomainauth] def validateKey(pubKey: String): Either[Throwable, PublicKey] = {
+    if ("[a-zA-Z0-9+/\n]+={0,3}".r.pattern.matcher(pubKey).matches) Right(PublicKey(pubKey))
     else Left(PublicKeyFormatException)
   }
 

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/package.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/package.scala
@@ -1,7 +1,7 @@
 package com.gu
 
 package object pandomainauth {
-  case class PublicKey(key: String)
-  case class PrivateKey(key: String)
-  case class Secret(secret: String)
+  case class PublicKey(key: String) extends AnyVal
+  case class PrivateKey(key: String) extends AnyVal
+  case class Secret(secret: String) extends AnyVal
 }

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/package.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/package.scala
@@ -1,0 +1,7 @@
+package com.gu
+
+package object pandomainauth {
+  case class PublicKey(key: String)
+  case class PrivateKey(key: String)
+  case class Secret(secret: String)
+}

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/CookieUtils.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/CookieUtils.scala
@@ -37,7 +37,7 @@ object CookieUtils {
   def generateCookieData(authUser: AuthenticatedUser, prvKey: PrivateKey): String = {
     val data = serializeAuthenticatedUser(authUser)
     val encodedData = new String(Base64.encodeBase64(data.getBytes("UTF-8")))
-    val signature = Crypto.signData(data.getBytes("UTF-8"), prvKey.key)
+    val signature = Crypto.signData(data.getBytes("UTF-8"), prvKey)
     val encodedSignature = new String(Base64.encodeBase64(signature))
 
     s"$encodedData.$encodedSignature"
@@ -50,7 +50,7 @@ object CookieUtils {
     cookieString match {
       case CookieRegEx(data, sig) =>
         try {
-          if (Crypto.verifySignature(Base64.decodeBase64(data.getBytes("UTF-8")), Base64.decodeBase64(sig.getBytes("UTF-8")), pubKey.key)) {
+          if (Crypto.verifySignature(Base64.decodeBase64(data.getBytes("UTF-8")), Base64.decodeBase64(sig.getBytes("UTF-8")), pubKey)) {
             deserializeAuthenticatedUser(new String(Base64.decodeBase64(data.getBytes("UTF-8"))))
           } else {
             throw new CookieSignatureInvalidException

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/CookieUtils.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/CookieUtils.scala
@@ -2,7 +2,8 @@ package com.gu.pandomainauth.service
 
 import java.security.SignatureException
 
-import com.gu.pandomainauth.model.{CookieParseException, CookieSignatureInvalidException, AuthenticatedUser, User}
+import com.gu.pandomainauth.{PrivateKey, PublicKey}
+import com.gu.pandomainauth.model.{AuthenticatedUser, CookieParseException, CookieSignatureInvalidException, User}
 import org.apache.commons.codec.binary.Base64
 
 object CookieUtils {
@@ -33,10 +34,10 @@ object CookieUtils {
     )
   }
 
-  def generateCookieData(authUser: AuthenticatedUser, prvKeyString: String): String = {
+  def generateCookieData(authUser: AuthenticatedUser, prvKey: PrivateKey): String = {
     val data = serializeAuthenticatedUser(authUser)
     val encodedData = new String(Base64.encodeBase64(data.getBytes("UTF-8")))
-    val signature = Crypto.signData(data.getBytes("UTF-8"), prvKeyString)
+    val signature = Crypto.signData(data.getBytes("UTF-8"), prvKey.key)
     val encodedSignature = new String(Base64.encodeBase64(signature))
 
     s"$encodedData.$encodedSignature"
@@ -44,12 +45,12 @@ object CookieUtils {
 
   lazy val CookieRegEx = "^^([\\w\\W]*)\\.([\\w\\W]*)$".r
 
-  def parseCookieData(cookieString: String, pubKeyStr: String): AuthenticatedUser = {
+  def parseCookieData(cookieString: String, pubKey: PublicKey): AuthenticatedUser = {
 
     cookieString match {
       case CookieRegEx(data, sig) =>
         try {
-          if (Crypto.verifySignature(Base64.decodeBase64(data.getBytes("UTF-8")), Base64.decodeBase64(sig.getBytes("UTF-8")), pubKeyStr)) {
+          if (Crypto.verifySignature(Base64.decodeBase64(data.getBytes("UTF-8")), Base64.decodeBase64(sig.getBytes("UTF-8")), pubKey.key)) {
             deserializeAuthenticatedUser(new String(Base64.decodeBase64(data.getBytes("UTF-8"))))
           } else {
             throw new CookieSignatureInvalidException

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/Crypto.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/Crypto.scala
@@ -3,6 +3,7 @@ package com.gu.pandomainauth.service
 import java.security.spec.{PKCS8EncodedKeySpec, X509EncodedKeySpec}
 import java.security.{KeyFactory, Security, Signature}
 
+import com.gu.pandomainauth.{PrivateKey, PublicKey}
 import org.apache.commons.codec.binary.Base64._
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 
@@ -22,18 +23,18 @@ object Crypto {
   val signatureAlgorithm: String = "SHA256withRSA"
   val keyFactory = KeyFactory.getInstance("RSA")
 
-  def signData(data: Array[Byte], prvKeyStr: String): Array[Byte] = {
+  def signData(data: Array[Byte], prvKey: PrivateKey): Array[Byte] = {
     val rsa = Signature.getInstance(signatureAlgorithm, "BC")
-    val privateKey = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(decodeBase64(prvKeyStr)))
+    val privateKey = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(decodeBase64(prvKey.key)))
     rsa.initSign(privateKey)
 
     rsa.update(data)
     rsa.sign()
   }
 
-  def verifySignature(data: Array[Byte], signature: Array[Byte], pubKeyStr: String) : Boolean = {
+  def verifySignature(data: Array[Byte], signature: Array[Byte], pubKey: PublicKey) : Boolean = {
     val rsa = Signature.getInstance(signatureAlgorithm, "BC")
-    val publicKey = keyFactory.generatePublic(new X509EncodedKeySpec(decodeBase64(pubKeyStr)))
+    val publicKey = keyFactory.generatePublic(new X509EncodedKeySpec(decodeBase64(pubKey.key)))
     rsa.initVerify(publicKey)
 
     rsa.update(data)

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/LegacyCookie.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/LegacyCookie.scala
@@ -3,6 +3,7 @@ package com.gu.pandomainauth.service
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
 
+import com.gu.pandomainauth.Secret
 import com.gu.pandomainauth.model.{AuthenticatedUser, CookieParseException, CookieSignatureInvalidException}
 import org.apache.commons.codec.binary.{Base64, Hex}
 
@@ -11,21 +12,21 @@ object LegacyCookie {
 
   lazy val CookieRegEx = "^^([\\w\\W]*)>>([\\w\\W]*)$".r
 
-  def generateCookieData(authUser: AuthenticatedUser, secret: String): String = {
+  def generateCookieData(authUser: AuthenticatedUser, secret: Secret): String = {
     val data = encode(CookieUtils.serializeAuthenticatedUser(authUser))
     val sign = generateSignature(data, secret)
 
     s"$data>>$sign"
   }
 
-  private def generateSignature(message: String, secret: String): String = {
+  private def generateSignature(message: String, secret: Secret): String = {
     val mac = Mac.getInstance("HmacSHA1")
-    mac.init(new SecretKeySpec(secret.getBytes, "HmacSHA1"))
+    mac.init(new SecretKeySpec(secret.secret.getBytes, "HmacSHA1"))
 
     new String(Hex.encodeHex(mac.doFinal(message.getBytes("UTF-8"))))
   }
 
-  def parseCookieData(cookieString: String, secret: String): AuthenticatedUser = {
+  def parseCookieData(cookieString: String, secret: Secret): AuthenticatedUser = {
 
     cookieString match {
       case CookieRegEx(data, sig) =>

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/LegacyCookie.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/LegacyCookie.scala
@@ -26,20 +26,6 @@ object LegacyCookie {
     new String(Hex.encodeHex(mac.doFinal(message.getBytes("UTF-8"))))
   }
 
-  def parseCookieData(cookieString: String, secret: Secret): AuthenticatedUser = {
-
-    cookieString match {
-      case CookieRegEx(data, sig) =>
-        val computedSig = generateSignature(data, secret)
-        if (safeEquals(sig, computedSig)) {
-            CookieUtils.deserializeAuthenticatedUser(decode(data))
-        } else {
-        throw new CookieSignatureInvalidException
-        }
-      case _ => throw new CookieParseException
-    }
-  }
-
   // Cribbed from the play framework equivalent - seems like a sound idea
   // Do not change this unless you understand the security issues behind timing attacks.
   // This method intentionally runs in constant time if the two strings have the same length.

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/PanDomainTest.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/PanDomainTest.scala
@@ -72,19 +72,4 @@ class PanDomainTest extends FreeSpec with Matchers with Inside {
       PanDomain.guardianValidation(invalidUser) should equal(false)
     }
   }
-
-  "authStatusWithLegacyCheck" - {
-    val authUser = AuthenticatedUser(User("test", "user", "test.user@example.com", None), "testsuite", Set("testsuite"), new Date().getTime + 86400, multiFactor = true)
-    val testSecret = "test"
-
-    "works with a new cookie" in {
-      val cookieData = CookieUtils.generateCookieData(authUser, testPrivateKey)
-      PanDomain.authStatusWithLegacyCheck(cookieData, testPublicKey, testSecret) shouldBe a[Authenticated]
-    }
-
-    "works with a legacy cookie" in {
-      val cookieData = LegacyCookie.generateCookieData(authUser, testSecret)
-      PanDomain.authStatusWithLegacyCheck(cookieData, testPublicKey, testSecret) shouldBe a[Authenticated]
-    }
-  }
 }

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/PublicSettingsTest.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/PublicSettingsTest.scala
@@ -23,13 +23,13 @@ class PublicSettingsTest extends FreeSpec with Matchers with EitherValues with S
 
     "returns the key if it is valid" in {
       val key = TestKeys.testPublicKey
-      PublicSettings.validateKey(key).right.value shouldEqual key
+      PublicSettings.validateKey(key.key).right.value shouldEqual key
     }
   }
 
   "extractPublicKey" - {
     "will get a public key from a valid settings map" in {
-      PublicSettings.extractPublicKey(Map("publicKey" -> TestKeys.testPublicKey)).futureValue shouldEqual TestKeys.testPublicKey
+      PublicSettings.extractPublicKey(Map("publicKey" -> TestKeys.testPublicKey.key)).futureValue shouldEqual TestKeys.testPublicKey
     }
 
     "will reject a key that is not correctly formatted" in {

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/PublicSettingsTest.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/PublicSettingsTest.scala
@@ -11,19 +11,19 @@ import org.scalatest.{EitherValues, FreeSpec, Matchers}
 class PublicSettingsTest extends FreeSpec with Matchers with EitherValues with ScalaFutures {
   "validateKey" - {
     "returns an error if the key looks invalid" in {
-      val invalidKey = "not a valid key"
+      val invalidKey = PublicKey("not a valid key")
       PublicSettings.validateKey(invalidKey).left.value shouldEqual PublicKeyFormatException
     }
 
     "returns an error if we have an S3 error instead of a key value" in {
-      val invalidKey = """<?xml version="1.0" encoding="UTF-8"?>
-                         |<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>5E5E15297AEDE946</RequestId><HostId>QmRYsD7HQmq7GtKC7CC9rZsv0MC/nWrppQQrAoMSNWku2ySkox5TlFIF8hk5wAUETeUa3xG9Jo4=</HostId></Error>"""
+      val invalidKey = PublicKey("""<?xml version="1.0" encoding="UTF-8"?>
+                         |<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>5E5E15297AEDE946</RequestId><HostId>QmRYsD7HQmq7GtKC7CC9rZsv0MC/nWrppQQrAoMSNWku2ySkox5TlFIF8hk5wAUETeUa3xG9Jo4=</HostId></Error>""")
       PublicSettings.validateKey(invalidKey).left.value shouldEqual PublicKeyFormatException
     }
 
     "returns the key if it is valid" in {
       val key = TestKeys.testPublicKey
-      PublicSettings.validateKey(key.key).right.value shouldEqual key
+      PublicSettings.validateKey(key).right.value shouldEqual key
     }
   }
 

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/service/LegacyCookieTest.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/service/LegacyCookieTest.scala
@@ -2,33 +2,16 @@ package com.gu.pandomainauth.service
 
 import java.util.Date
 
-import com.gu.pandomainauth.model.{CookieSignatureInvalidException, CookieParseException, User, AuthenticatedUser}
-import org.scalatest.{Matchers, FreeSpec}
+import com.gu.pandomainauth.Secret
+import com.gu.pandomainauth.model.{AuthenticatedUser, CookieParseException, CookieSignatureInvalidException, User}
+import org.scalatest.{FreeSpec, Matchers}
 
 class LegacyCookieTest extends FreeSpec with Matchers {
   val authUser = AuthenticatedUser(User("test", "user", "test.user@example.com", None), "testsuite", Set("testsuite", "another"), new Date().getTime + 86400, multiFactor = true)
   val data = CookieUtils.serializeAuthenticatedUser(authUser)
-  val secret = "testSecret"
-
-  "generate/parse round trip restores a valid authedUser" in {
-    LegacyCookie.parseCookieData(LegacyCookie.generateCookieData(authUser, secret), secret) should equal(authUser)
-  }
+  val secret = Secret("testSecret")
 
   "generateCookieData should create a cookie value with the correct structure" in {
     LegacyCookie.generateCookieData(authUser, secret) should fullyMatch regex "^^([\\w\\W]*)>>([\\w\\W]*)$".r
-  }
-
-  "parseCookieData" - {
-    "throws a CookieParseException when given invalid data" in {
-      intercept[CookieParseException] {
-        LegacyCookie.parseCookieData("bad cookie data", secret)
-      }
-    }
-
-    "throws a CookieParseException if the signature is invalid" in {
-      intercept[CookieSignatureInvalidException] {
-        LegacyCookie.parseCookieData("data>>invalid-signature", secret)
-      }
-    }
   }
 }

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/service/TestKeys.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/service/TestKeys.scala
@@ -1,11 +1,14 @@
 package com.gu.pandomainauth.service
 
+import com.gu.pandomainauth.{PrivateKey, PublicKey}
+
 object TestKeys {
 
   /**
    * A test public/private key-pair
    */
-  val testPublicKey = """MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA5AGsiD19GMj8p8jFLRAg
+  val testPublicKey = PublicKey(
+                      """MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA5AGsiD19GMj8p8jFLRAg
                         |k0z8SFrOU7J3VBCsSn6ByS9tMpkvI9PFWwcmwxgGXAbWkPWOfyC0nNyQPx8MhgRt
                         |zqS+X6j07juaaLnkHh8KmdLYyE7JGH9AfTI2gNI2qvSFhlvYqX8EVVSmooMz6zBu
                         |TIrn9aT9eJRsqBtNw5NKp2lB7FIBUs6by9apZxXXJbwNwe+sIAIpin2Mhg9mQjjS
@@ -16,8 +19,9 @@ object TestKeys {
                         |k5VsihN5iSGSlTqy1/sBppxsd+1955ukKmJsbdbHZoVceqKpVAIlXt8uFHybRp1y
                         |q19rXt5nBnpqVND80oPPn1wc1WrSy1sm8aQwtKSBoNJgvO6diuKPtX2BnQxzKjEw
                         |p2RyzmRIBIw16kjPNLKGgakrJOZP51gFdOA1qjUA44w0V2mxbszq40aMYFsI5Kyd
-                        |qqXkOlqIoeN8DHVaNBPiSakCAwEAAQ==""".stripMargin
-  val testPrivateKey = """MIIJKQIBAAKCAgEA5AGsiD19GMj8p8jFLRAgk0z8SFrOU7J3VBCsSn6ByS9tMpkv
+                        |qqXkOlqIoeN8DHVaNBPiSakCAwEAAQ==""".stripMargin)
+  val testPrivateKey = PrivateKey(
+                       """MIIJKQIBAAKCAgEA5AGsiD19GMj8p8jFLRAgk0z8SFrOU7J3VBCsSn6ByS9tMpkv
                          |I9PFWwcmwxgGXAbWkPWOfyC0nNyQPx8MhgRtzqS+X6j07juaaLnkHh8KmdLYyE7J
                          |GH9AfTI2gNI2qvSFhlvYqX8EVVSmooMz6zBuTIrn9aT9eJRsqBtNw5NKp2lB7FIB
                          |Us6by9apZxXXJbwNwe+sIAIpin2Mhg9mQjjSMSKet0NY3THlUQwGSCvMVs+CD9My
@@ -65,12 +69,13 @@ object TestKeys {
                          |YKkd8Tsi/AKIOmPmGQo7OueR/ogeicTLPhidoG9409x1rmKyEsFwjbHTXbQPqhYa
                          |wXED1ryRmJJQ0YvAm53fex+Hvh6+8gCAP0Rb13UaQnnD53+OPYpzqcoGL5idrhnb
                          |Uk5PRs9HcBnKK3+FLkzvu2lJsUd9LxZCNjabNslaiaJAc98DJCaHgplPhoyRpc5l
-                         |CPdFb0yoYfBZjP3DRXJj2koucqru+2tu2WX+HT216OrB8b20CmUlUynwJvtj""".stripMargin
+                         |CPdFb0yoYfBZjP3DRXJj2koucqru+2tu2WX+HT216OrB8b20CmUlUynwJvtj""".stripMargin)
 
   /**
    * A valid private key that does not match the public key (useful to test things fail with the wrong key)
    */
-  val testINCORRECTPrivateKey = """MIIEpQIBAAKCAQEA2rEzkKiGmC1Dy+MlBESQDhaokUKGKnbyB+8AoZ3dWvMKkUiC
+  val testINCORRECTPrivateKey = PrivateKey(
+                                """MIIEpQIBAAKCAQEA2rEzkKiGmC1Dy+MlBESQDhaokUKGKnbyB+8AoZ3dWvMKkUiC
                                   |u6LoXRPePT9ncKVtJk0fnv08Ca+eP4JOaVJMxZoHnDzhwMeRzmofHlqE6IMsU0vq
                                   |ZHZLV0+WDRCjlScZ5xq/Pvi2HUXTDrGp+DmLzibkerPBNd6f2sMeGpuGXD6ha0no
                                   |PyWjXDmhKioaadoYvgyHZ/i5gbOVFRmBzNadsgemAo8FGtAPIE3cd0AKfgAuuGyW
@@ -94,5 +99,5 @@ object TestKeys {
                                   |VXKUJ9NC3B7uXbyOhWbMrFAdh9TugWM1MdtxRn5hVCyhz2qKDbA5nKKiLmvhM+bd
                                   |Rx4btn8CgYEA8tCxTDjHi/TA3KV5+rHjCo0IYRIvywg6bqy0dDwcZjQ288bm3qPD
                                   |o9PbUxP5TRl8LwEorThRXatdFvOwKC5LDtzyXWzkHbpV2Yu+e5QGZw2HGOKZ3AjC
-                                  |JYA7mT0eNFmOa/d1W8NdXhh6YKYiV4y8q07WVtLUnBowMoa8tgB/53w=""".stripMargin
+                                  |JYA7mT0eNFmOa/d1W8NdXhh6YKYiV4y8q07WVtLUnBowMoa8tgB/53w=""".stripMargin)
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.0-SNAPSHOT"
+version in ThisBuild := "0.3.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.0"
+version in ThisBuild := "0.3.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.15-SNAPSHOT"
+version in ThisBuild := "0.3.0-SNAPSHOT"


### PR DESCRIPTION
@piuccio pointed out yesterday that we are still entirely relying on the Legacy cookie in Pan Domain authed Play apps. Turns out that there also seem to be chunks of code that simply shouldn't work or don't do what we would expect.

There are two cookies - the legacy one with the name from `PublicSettings.cookieName` - which must be decoded with the `LegacyCookie` and the `secret`. Secondly there is the new one with the name `PublicSettings.assymCookieName` (if it wasn't going to break everything I'd fix this spelling) which must be decoded with `CookieUtils` and the `publicKey`.

There are a number of places where we try to decode a cookie with either the wrong decoder or the wrong key (the latter throws an exception, so some paths are clearly never being used). Either way - we should now be in a position where we solely rely on the asymmetric cookie, so we should never read from `PublicSettings.cookieName` or use `LegacyCookie` or `secret` for decoding it.

It also turns out that in some places we were discarding decoded cookies entirely - despite comments to the contrary - I've tried to fix those.