### PR TITLE
Fix a couple of problems with the user validation logic.

### DIFF
--- a/pan-domain-auth-play_2-4-0/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-4-0/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -25,7 +25,7 @@ trait AuthActions extends PanDomainAuth {
    * @param authedUser
    * @return true if the user is valid in your app
    */
-  def validateUser(authedUser: AuthenticatedUser): Boolean
+  def validateUser(authedUser: AuthenticatedUser): Boolean = PanDomain.guardianValidation(authedUser)
 
 
   /**
@@ -198,15 +198,7 @@ trait AuthActions extends PanDomainAuth {
    */
   def extractAuth(request: RequestHeader): AuthenticationStatus = {
     readCookie(request).map { cookie =>
-      PanDomain.authStatus(cookie.value, settings.publicKey) match {
-        case Expired(authedUser) if authedUser.isInGracePeriod(apiGracePeriod) =>
-          GracePeriod(authedUser)
-        case authStatus @ Authenticated(authedUser) =>
-          if (cacheValidation && authedUser.authenticatedIn(system)) authStatus
-          else if (validateUser(authedUser)) authStatus
-          else NotAuthorized(authedUser)
-        case authStatus => authStatus
-      }
+      PanDomain.authStatus(cookie.value, settings.publicKey, validateUser, apiGracePeriod, system, cacheValidation)
     } getOrElse NotAuthenticated
   }
 

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PanDomain.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PanDomain.scala
@@ -8,23 +8,38 @@ object PanDomain {
   /**
    * Check the authentication status of the provided credentials by examining the signed cookie data.
    */
-  def authStatus(cookieData: String, publicKey: PublicKey, validateUser: AuthenticatedUser => Boolean = guardianValidation): AuthenticationStatus = {
+  def authStatus(cookieData: String, publicKey: PublicKey, validateUser: AuthenticatedUser => Boolean, apiGracePeriod: Long, system: String, cacheValidation: Boolean): AuthenticationStatus = {
     try {
       val authedUser = CookieUtils.parseCookieData(cookieData, publicKey)
-      checkStatus(authedUser, validateUser)
+
+      if (authedUser.isExpired && authedUser.isInGracePeriod(apiGracePeriod)) {
+        // expired, but in grace period - check user is valid, GracePeriod if so
+        if (cacheValidation && authedUser.authenticatedIn(system)) {
+          // if validation is cached, check user has been validated here
+          GracePeriod(authedUser)
+        } else if (validateUser(authedUser)) {
+          // validation says this user is ok
+          GracePeriod(authedUser)
+        } else {
+          // the user is in the grace period but has failed validation
+          NotAuthorized(authedUser)
+        }
+      } else if (authedUser.isExpired) {
+        // expired and outside grace period
+        Expired(authedUser)
+      } else if (cacheValidation && authedUser.authenticatedIn(system)) {
+        // if cacheValidation is enabled, check the user was validated here
+        Authenticated(authedUser)
+      } else if (validateUser(authedUser)) {
+        // fresh validation says the user is valid
+        Authenticated(authedUser)
+      } else {
+        // user has not expired but has failed validation checks
+        NotAuthorized(authedUser)
+      }
     } catch {
       case e: Exception =>
         InvalidCookie(e)
-    }
-  }
-
-  private def checkStatus(authedUser: AuthenticatedUser, validateUser: AuthenticatedUser => Boolean = guardianValidation): AuthenticationStatus = {
-    if (authedUser.isExpired) {
-      Expired(authedUser)
-    } else if (validateUser(authedUser)) {
-      Authenticated(authedUser)
-    } else {
-      NotAuthorized(authedUser)
     }
   }
 

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/PanDomainTest.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/PanDomainTest.scala
@@ -10,43 +10,91 @@ class PanDomainTest extends FreeSpec with Matchers with Inside {
   import com.gu.pandomainauth.service.TestKeys._
 
   "authStatus" - {
-    val authUser = AuthenticatedUser(User("test", "user", "test.user@example.com", None), "testsuite", Set("testsuite"), new Date().getTime + 86400, multiFactor = true)
+    val authUser = AuthenticatedUser(User("test", "user", "test.user@example.com", None), "testsuite", Set("system"), new Date().getTime + 86400, multiFactor = true)
+    val validCookieData = CookieUtils.generateCookieData(authUser, testPrivateKey)
 
     "returns `Authenticated` for valid cookie data that passes the validation check" in {
-      def validateUser(au: AuthenticatedUser): Boolean = au.multiFactor && au.user.emailDomain == "example.com"
-      val cookieData = CookieUtils.generateCookieData(authUser, testPrivateKey)
-
-      PanDomain.authStatus(cookieData, testPublicKey, validateUser) shouldBe a [Authenticated]
+      PanDomain.authStatus(validCookieData, testPublicKey, _ => true, 0, "system", false) shouldBe a [Authenticated]
     }
 
     "gives back the provided auth user if successful" in {
       val cookieData = CookieUtils.generateCookieData(authUser, testPrivateKey)
 
-      PanDomain.authStatus(cookieData, testPublicKey, _ => true) should equal(Authenticated(authUser))
+      PanDomain.authStatus(cookieData, testPublicKey, _ => true, 0, "system", false) should equal(Authenticated(authUser))
     }
 
     "returns `InvalidCookie` if the cookie is not valid" in {
-      PanDomain.authStatus("invalid cookie data", testPublicKey, _ => true) shouldBe a [InvalidCookie]
+      PanDomain.authStatus("invalid cookie data", testPublicKey, _ => true, 0, "system", false) shouldBe a [InvalidCookie]
     }
 
     "returns `InvalidCookie` if the cookie fails its signature check" in {
       val incorrectCookieData = CookieUtils.generateCookieData(authUser, testINCORRECTPrivateKey)
 
-      PanDomain.authStatus(incorrectCookieData, testPublicKey, _ => true) shouldBe a [InvalidCookie]
+      PanDomain.authStatus(incorrectCookieData, testPublicKey, _ => true, 0, "system", false) shouldBe a [InvalidCookie]
     }
 
-    "returns `Expired` if the time is after the cookie's expiry" in {
-      val expiredAuthUser = authUser.copy(expires = new Date().getTime - 86400)
-      val cookieData = CookieUtils.generateCookieData(expiredAuthUser, testPrivateKey)
+    "when the user's login has expired" - {
+      "returns `Expired` if the time is after the cookie's expiry" in {
+        val expiredAuthUser = authUser.copy(expires = new Date().getTime - 86400)
+        val cookieData = CookieUtils.generateCookieData(expiredAuthUser, testPrivateKey)
 
-      PanDomain.authStatus(cookieData, testPublicKey, _ => true) shouldBe a [Expired]
+        PanDomain.authStatus(cookieData, testPublicKey, _ => true, 0, "system", false) shouldBe a [Expired]
+      }
+
+      "returns `Expired` if the cookie has expired and is outside the grace period" in {
+        val expiredAuthUser = authUser.copy(expires = new Date().getTime - 86400)
+        val cookieData = CookieUtils.generateCookieData(expiredAuthUser, testPrivateKey)
+
+        PanDomain.authStatus(cookieData, testPublicKey, _ => true, 3600, "system", false) shouldBe a [Expired]
+      }
+
+      "returns grace period if the cookie has expired but is within the grace period" in {
+        val expiredAuthUser = authUser.copy(expires = new Date().getTime - 3000)
+        val cookieData = CookieUtils.generateCookieData(expiredAuthUser, testPrivateKey)
+
+        PanDomain.authStatus(cookieData, testPublicKey, _ => true, 3600, "system", false) shouldBe a [GracePeriod]
+      }
     }
 
-    "returns `NotAuthorized` if the cookie does not pass the verification check" in {
-      def validateUser(au: AuthenticatedUser): Boolean = au.multiFactor && au.user.emailDomain == "example.com"
-      val cookieData = CookieUtils.generateCookieData(authUser, testPrivateKey)
+    "correctle handles the verification check" - {
+      val invalid: AuthenticatedUser => Boolean = _ => false
+      val valid: AuthenticatedUser => Boolean = _ => true
 
-      PanDomain.authStatus(cookieData, testPublicKey, _ => false) shouldBe a [NotAuthorized]
+      "without cached validation, " - {
+        val notCached = false
+
+        "returns NotAuthorized if the user fails the validation check" in {
+          PanDomain.authStatus(validCookieData, testPublicKey, invalid, 0, "system", notCached) shouldBe a [NotAuthorized]
+        }
+
+        "returns Authenticated if the user passes the validation check" in {
+          PanDomain.authStatus(validCookieData, testPublicKey, valid, 0, "system", notCached) shouldBe a [Authenticated]
+        }
+      }
+
+      "when validation is cached, " - {
+        val cached = true
+
+        "returns NotAuthorized if the user is not authorized in this system" in {
+          val status = PanDomain.authStatus(validCookieData, testPublicKey, invalid, 0, "not-the-system", cacheValidation = true)
+          status shouldBe a [NotAuthorized]
+        }
+
+        "returns Authenticated if the user was authenticated in this system, even if they would fail the validation check" in {
+          val status = PanDomain.authStatus(validCookieData, testPublicKey, invalid, 0, "system", cacheValidation = true)
+          status shouldBe a [Authenticated]
+        }
+
+        "does not call the validateUser function if caching is enabled" in {
+          var called = false
+          val validateUser: AuthenticatedUser => Boolean = { _ =>
+            called = true
+            false
+          }
+          PanDomain.authStatus(validCookieData, testPublicKey, validateUser, 0, "system", cacheValidation = true)
+          called shouldEqual false
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Moves auth validation logic into one place and adds tests to address the following issues:

1. it was impossible to override the `guardianValidation` check
2. users in the grace period skipped the validation checks

cc @DiegoVazquezNanini @jennysivapalan 

## 1
In the first case, for any projects using panda that wanted to enforce non-Guardian rules (for example changing the email domain or dropping the 2FA requirement), it was impossible to properly override the validateUser check. The overridable validateUser function was used at session creation time, but the `guardianValidation` function was erroneously hard-coded for the subsequent session validation. This caused very confusing results.

We now consistently apply the project-provided validateUser function. This may cause problems for existing applications but only in surprising cases and if the projects were already doing crazy things.

## 2
This was a potential security issue, although exploiting it would depend on finding a project that behaves in a way we'd probably class as "not recommended".

If the project-supplied validateUser function is impure then it's possible that it would being to fail at some point after the original session has been issued. For example, there might be a session-revocation feature that returns false if the user has been blacklisted in some way. This check would have been bypassed during the grace period providing an attacker with a window of opportunity to exploit a compromised session.

It's worth noting that while it's unlikely this affects any of our projects, the pan-domain-auth library was designed to support these use cases (this is why the `cache validation` feature exists). Ignoring questions about whether these features make any sense the way they are implemented in panda, this Pull Request fixes this edge case.
