### PR TITLE
fix play26 project compile

### DIFF
--- a/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/service/GoogleAuth.scala
+++ b/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/service/GoogleAuth.scala
@@ -77,7 +77,7 @@ class GoogleAuth(config: GoogleAuthSettings, system: String, redirectUrl: String
             val token = Token.fromJson(json)
             val jwt = token.jwt
             ws.url(dd.userinfo_endpoint)
-              .withHeaders("Authorization" -> s"Bearer ${token.access_token}")
+              .withHttpHeaders("Authorization" -> s"Bearer ${token.access_token}")
               .get().map { response =>
               googleResponse(response) { json =>
                 val userInfo = UserInfo.fromJson(json)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,10 @@ object Dependencies {
     Seq(
       "com.typesafe.play" %% "play" % version % "provided",
       "com.typesafe.play" %% "play-ws" % version % "provided",
-      "commons-codec" % "commons-codec" % "1.10"
+      "commons-codec" % "commons-codec" % "1.10",
+      "joda-time" % "joda-time" % "2.9.9",
+      "org.joda" % "joda-convert" % "1.9.2"
+
     )
   }
 


### PR DESCRIPTION
there were two compile errors:
- `method withHeaders in trait WSRequest is deprecated: Use withHttpHeaders or addHttpHeaders`
- `[error] Class org.joda.convert.FromString not found - continuing with a stub.`
