### PR TITLE
bump libraries for security

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,11 +39,32 @@ object Dependencies {
   )
 
   val cryptoDependencies = Seq(
-    "org.bouncycastle" % "bcprov-jdk16" % "1.46",
+    "org.bouncycastle" % "bcprov-jdk15on" % "1.58",
     "commons-codec" % "commons-codec" % "1.10"
   )
 
   val testDependencies = Seq("org.scalatest" %% "scalatest" % "2.2.6" % "test")
 
-  val httpClient = Seq("net.databinder.dispatch" %% "dispatch-core" % "0.11.3")
+  val httpClient = Seq("net.databinder.dispatch" %% "dispatch-core" % "0.11.4")
+
+  /*
+  * Pull in an updated version of jackson and logback libraries as the ones AWS use have security vulnerabilities.
+  * See https://github.com/aws/aws-sdk-java/pull/1373
+  * */
+  val jackson: Seq[ModuleID] = {
+    val version = "2.9.2"
+    Seq(
+      "com.fasterxml.jackson.core" % "jackson-core" % version,
+      "com.fasterxml.jackson.core" % "jackson-databind" % version,
+      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % version
+    )
+  }
+
+  val logback: Seq[ModuleID] = {
+    val version = "1.2.3"
+    Seq(
+      "ch.qos.logback" % "logback-core" % version,
+      "ch.qos.logback" % "logback-classic" % version
+    )
+  }
 }

--- a/project/PanDomainAuthenticationBuild.scala
+++ b/project/PanDomainAuthenticationBuild.scala
@@ -77,7 +77,14 @@ object PanDomainAuthenticationBuild extends Build {
   lazy val panDomainAuthVerification = project("pan-domain-auth-verification")
     .settings(sonatypeReleaseSettings: _*)
     .settings(
-      libraryDependencies ++= cryptoDependencies ++ testDependencies ++ httpClient ++ akkaDependencies ++ scheduler,
+      libraryDependencies
+        ++= cryptoDependencies
+        ++ testDependencies
+        ++ httpClient
+        ++ akkaDependencies
+        ++ scheduler
+        ++ jackson
+        ++ logback,
       publishArtifact := true
     )
 


### PR DESCRIPTION
Branched off https://github.com/guardian/pan-domain-authentication/pull/36, which should be reviewed first.

Address the following issues found by Snyk:
- https://snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-30208
- https://snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-31407
- https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31507
- https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31519
- https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31520
- https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31573
- https://snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-31049

Have tested this in Media Atom Maker in DEV.