### PR TITLE
Fix pan domain settings refresher

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,26 +244,15 @@ import com.gu.pandomainauth.model.AuthenticatedUser
 
 trait PanDomainAuthActions extends AuthActions {
 
-  import play.api.Play.current
-  lazy val config = play.api.Play.configuration
-
   override def validateUser(authedUser: AuthenticatedUser): Boolean = {
     (authedUser.user.email endsWith ("@guardian.co.uk")) && authedUser.multiFactor
   }
 
-  override def cacheValidation = true
+  def config: Configuration
 
-  override def authCallbackUrl: String = config.getString("host").get + "/oauthCallback"
+  override def cacheValidation = false
 
-  override lazy val domain: String = config.getString("pandomain.domain").get
-
-  lazy val awsSecretAccessKey: String = config.getString("pandomain.aws.secret")
-  lazy val awsKeyId: String = config.getString("pandomain.aws.keyId")
-  override lazy val awscredentials =
-    for (key <- awsKeyId; secret <- awsSecretAccessKey)
-    yield new BasicAWSCredentials(key, secret)
-
-  override lazy val system: String = "workflow"
+  override def authCallbackUrl: String = config.get[String]("host") + "/oauthCallback"
 }
 ```
 
@@ -273,14 +262,19 @@ validation will only reoccur when the Google session is refreshed)
 
 Create a controller that will handle the oauth callback and logout actions, add these actions to the routes file.
 
-``` scala
+```scala
 package controllers
 
 import play.api.mvc._
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
-object Login extends Controller with PanDomainAuthActions {
+class Login(
+  override val controllerComponents: ControllerComponents,
+  override val config: Configuration,
+  override val wsClient: WSClient,
+  override val panDomainSettings: PanDomainAuthSettingsRefresher
+) extends AbstractController(controllerComponents) with PanDomainAuthActions {
 
   def oauthCallback = Action.async { implicit request =>
     processGoogleCallback()
@@ -294,7 +288,7 @@ object Login extends Controller with PanDomainAuthActions {
 
 Add the `AuthAction` or `ApiAuthAction` to any endpoints you with to require an authenticated user for.
 
-``` scala
+```scala
 package controllers
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -302,7 +296,12 @@ import lib._
 import play.api.mvc._
 
 
-object Application extends Controller with PanDomainAuthActions {
+object Application(
+  override val controllerComponents: ControllerComponents,
+  override val config: Configuration,
+  override val wsClient: WSClient,
+  override val panDomainSettings: PanDomainAuthSettingsRefresher
+) extends AbstractController(controllerComponents) with PanDomainAuthActions {
 
   def loginStatus = AuthAction { request =>
     val user = request.user
@@ -343,6 +342,22 @@ object Application extends Controller with PanDomainAuthActions {
   See also [Customising error responses for an authenticated API]().
 
 Both the actions add the current user to the request, this is available as `request.user`.
+
+In order to instantiate your controller you'll need an instance of PanDomainAuthSettingsRefresher. This one cane be manually created during the wiring of your application (application loader).
+Here's an example of instantiation:
+
+```scala
+  val awsCredentialsProvider = ...
+
+  val panDomainSettings = new PanDomainAuthSettingsRefresher(
+    domain = "local.dev-gutools.co.uk",
+    system = "example",
+    actorSystem = actorSystem,
+    awsCredentialsProvider = awsCredentialsProvider // optional as there's a default value to DefaultAWSCredentialsProviderChain
+  )
+
+  val controller = new AdminController(controllerComponents, configuration, wsClient, panDomainSettings)
+```
 
 ### Using pan domain auth with another framework
 

--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/PanDomainAuthSettingsRefresher.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/PanDomainAuthSettingsRefresher.scala
@@ -14,47 +14,30 @@ import com.gu.pandomainauth.service.{ProxyConfiguration, S3Bucket}
 
 import scala.concurrent.duration.FiniteDuration
 
-
-trait PanDomainAuth {
-
-  def actorSystem: ActorSystem
-
-  /**
-   * the domain you are authin agains
-   * @return
-   */
-  def domain: String
-
-  /**
-   * the identifier for your app, typically the same as the subdomain your app runs on
-   * @return
-   */
-  def system: String
-
-  /**
-   * the AwsCredentials to access the configuration bucket, defaults to None so the instance credentials are used
-   * @return
-   */
-  def awsCredentialsProvider: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain()
-
-  /**
-   * the aws region the configuration bucket is in, defaults to eu-west-1 as that's where the guardian tends to run stuff
-   * @return
-   */
-  def awsRegion: Option[Region] = Option( Region getRegion Regions.EU_WEST_1 )
-
-  /**
-   * the proxy configuration to use when connecting to aws
-   * @return
-   */
-  def proxyConfiguration: Option[ProxyConfiguration] = None
-
+/**
+  * PanDomainAuthSettingsRefresher will periodically refresh the pan domain settings and expose them via the "settings" method
+  *
+  * @param domain the domain you are authin agains
+  * @param system the identifier for your app, typically the same as the subdomain your app runs on
+  * @param actorSystem the actor system to create the refresh actor
+  * @param awsCredentialsProvider optional credential provider
+  * @param awsRegion optional region
+  * @param proxyConfiguration optional proxy configuration
+  */
+class PanDomainAuthSettingsRefresher(
+  val domain: String,
+  val system: String,
+  actorSystem: ActorSystem,
+  awsCredentialsProvider: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain(),
+  awsRegion: Option[Region] = Option(Region getRegion Regions.EU_WEST_1),
+  proxyConfiguration: Option[ProxyConfiguration] = None
+) {
   lazy val bucket = new S3Bucket(awsCredentialsProvider, awsRegion, proxyConfiguration)
 
-  lazy val settingsMap = bucket.readDomainSettings(domain)
-  lazy val authSettings: Agent[PanDomainAuthSettings] = Agent(PanDomainAuthSettings(settingsMap))
+  private lazy val settingsMap = bucket.readDomainSettings(domain)
+  private lazy val authSettings: Agent[PanDomainAuthSettings] = Agent(PanDomainAuthSettings(settingsMap))
 
-  lazy val domainSettingsRefreshActor = actorSystem.actorOf(Props(classOf[DomainSettingsRefreshActor], domain, bucket, authSettings), "PanDomainAuthSettingsRefresher")
+  private lazy val domainSettingsRefreshActor = actorSystem.actorOf(Props(classOf[DomainSettingsRefreshActor], domain, bucket, authSettings), "PanDomainAuthSettingsRefresher")
 
   actorSystem.scheduler.scheduleOnce(1 minute, domainSettingsRefreshActor, Refresh)
 

--- a/pan-domain-auth-example/app/controllers/AdminController.scala
+++ b/pan-domain-auth-example/app/controllers/AdminController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import akka.actor.ActorSystem
+import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import play.api.Configuration
 import play.api.mvc.{AbstractController, ControllerComponents}
 import play.api.libs.ws.WSClient
@@ -10,7 +10,7 @@ class AdminController(
   override val controllerComponents: ControllerComponents,
   override val config: Configuration,
   override val wsClient: WSClient,
-  override val actorSystem: ActorSystem
+  override val panDomainSettings: PanDomainAuthSettingsRefresher
 ) extends AbstractController(controllerComponents) with ExampleAuthActions {
 
   def index = Action{Ok("hello")}

--- a/pan-domain-auth-example/app/controllers/ExampleAuthActions.scala
+++ b/pan-domain-auth-example/app/controllers/ExampleAuthActions.scala
@@ -1,8 +1,5 @@
 package controllers
 
-import com.amazonaws.auth.{AWSCredentialsProvider, BasicAWSCredentials}
-import com.amazonaws.internal.StaticCredentialsProvider
-import com.amazonaws.regions.Region
 import com.gu.pandomainauth.PanDomain
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
@@ -20,18 +17,4 @@ trait ExampleAuthActions extends AuthActions {
   override def cacheValidation = false
 
   override def authCallbackUrl: String = config.get[String]("host") + "/oauthCallback"
-
-  override lazy val domain: String = "local.dev-gutools.co.uk"
-  lazy val awsSecretAccessKey: String = config.get[String]("aws.secret")
-  lazy val awsKeyId: String = config.get[String]("aws.keyId")
-
-  override lazy val awsCredentialsProvider: AWSCredentialsProvider = new StaticCredentialsProvider(new BasicAWSCredentials(awsKeyId, awsSecretAccessKey))
-
-  /**
-   * the aws region the configuration bucket is in, defaults to eu-west-1 as that's where the guardian tends to run stuff
-   * @return
-   */
-  override def awsRegion: Option[Region] = super.awsRegion
-
-  override lazy val system: String = "example"
 }

--- a/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -2,7 +2,7 @@ package com.gu.pandomainauth.action
 
 import com.gu.pandomainauth.model._
 import com.gu.pandomainauth.service._
-import com.gu.pandomainauth.{PanDomain, PanDomainAuth, PublicSettings}
+import com.gu.pandomainauth.{PanDomain, PanDomainAuthSettingsRefresher, PublicSettings}
 import play.api.Logger
 import play.api.libs.ws.WSClient
 import play.api.mvc.Results._
@@ -12,13 +12,18 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class UserRequest[A](val user: User, request: Request[A]) extends WrappedRequest[A](request)
 
-trait AuthActions extends PanDomainAuth {
+trait AuthActions {
 
   /**
     * Play application components that you must provide in order to use AuthActions
     */
   def wsClient: WSClient
   def controllerComponents: ControllerComponents
+  def panDomainSettings: PanDomainAuthSettingsRefresher
+
+  private def system: String = panDomainSettings.system
+  private def domain: String = panDomainSettings.domain
+  private def settings: PanDomainAuthSettings = panDomainSettings.settings
 
   private implicit val ec: ExecutionContext = controllerComponents.executionContext
 
@@ -65,7 +70,7 @@ trait AuthActions extends PanDomainAuth {
 
   val GoogleAuth = new GoogleAuth(settings.googleAuthSettings, system, authCallbackUrl)
 
-  val multifactorChecker = settings.google2FAGroupSettings.map(new Google2FAGroupChecker(_, bucket))
+  val multifactorChecker = settings.google2FAGroupSettings.map(new Google2FAGroupChecker(_, panDomainSettings.bucket))
 
   /**
     * A Play session key that stores the target URL that was being accessed when redirected for authentication


### PR DESCRIPTION
The actor system was instantiated for each controller. This changed when
the actor system was passed down as a parameter, which in turn created
more problems as the domain settings refresher was instantiated for
each controller leading to a name collision.

This attempts to fix it by extracting the refresher logic out of the
trait, and requiring it to be injected in each controller

cc @regiskuckaertz