### PR TITLE
Non blocking s3 call and further improvements

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   val awsDependencies = Seq("com.amazonaws" % "aws-java-sdk-s3" % "1.11.8")
 
-  val akkaDependencies = Seq("com.typesafe.akka" %% "akka-agent" % "2.4.20")
+  val akkaDependencies = Seq("com.typesafe.akka" %% "akka-actor" % "2.5.4")
 
   val scheduler = Seq("org.quartz-scheduler" % "quartz" % "2.2.3")
 


### PR DESCRIPTION
I was bothered by some more stuff: Calls to s3 are blocking, and it's still using the deprecated agents.

 - Don't block when on S3, my approach may not be deemed "scala" enough, please be candid while reviewing. It's a cheap way to avoid blocking on Play's actor system
 - Remove Agents, and update the actor library to the same as play 2.6.11
 - Don't use the global execution context as we have one provided by the actor system

cc @regiskuckaertz