### PR TITLE
Support other OAuth providers

### DIFF
--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/PanDomainAuthSettingsRefresher.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/PanDomainAuthSettingsRefresher.scala
@@ -19,20 +19,22 @@ import scala.concurrent.duration.FiniteDuration
   *
   * @param domain the domain you are authin agains
   * @param system the identifier for your app, typically the same as the subdomain your app runs on
+  * @param bucketName the bucket where the settings are stored
   * @param actorSystem the actor system to create the refresh actor
-  * @param awsCredentialsProvider optional credential provider
-  * @param awsRegion optional region
+  * @param awsCredentialsProvider AWS credential provider
+  * @param awsRegion AWS region
   * @param proxyConfiguration optional proxy configuration
   */
 class PanDomainAuthSettingsRefresher(
   val domain: String,
   val system: String,
+  bucketName: String,
   actorSystem: ActorSystem,
-  awsCredentialsProvider: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain(),
-  awsRegion: Option[Region] = Option(Region getRegion Regions.EU_WEST_1),
+  awsCredentialsProvider: AWSCredentialsProvider,
+  awsRegion: String,
   proxyConfiguration: Option[ProxyConfiguration] = None
 ) {
-  lazy val bucket = new S3Bucket(awsCredentialsProvider, awsRegion, proxyConfiguration)
+  lazy val bucket = new S3Bucket(bucketName, awsCredentialsProvider, awsRegion, proxyConfiguration)
 
   private lazy val settingsMap = bucket.readDomainSettings(domain)
   private lazy val authSettings: Agent[PanDomainAuthSettings] = Agent(PanDomainAuthSettings(settingsMap))

--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/PanDomainAuthSettingsRefresher.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/PanDomainAuthSettingsRefresher.scala
@@ -31,7 +31,7 @@ class PanDomainAuthSettingsRefresher(
   bucketName: String,
   actorSystem: ActorSystem,
   awsCredentialsProvider: AWSCredentialsProvider,
-  awsRegion: String,
+  awsRegion: Regions,
   proxyConfiguration: Option[ProxyConfiguration] = None
 ) {
   lazy val bucket = new S3Bucket(bucketName, awsCredentialsProvider, awsRegion, proxyConfiguration)

--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/PanDomainAuthSettings.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/PanDomainAuthSettings.scala
@@ -1,20 +1,20 @@
 package com.gu.pandomainauth.model
 
-import com.gu.pandomainauth.{PrivateKey, PublicKey, PublicSettings, Secret}
+import com.gu.pandomainauth.{PrivateKey, PublicKey, Secret}
 
 case class PanDomainAuthSettings(
   secret: Secret,
   publicKey: PublicKey,
   privateKey: PrivateKey,
+  cookieSettings: CookieSettings,
   googleAuthSettings: GoogleAuthSettings,
   google2FAGroupSettings: Option[Google2FAGroupSettings]
-) {
-  @deprecated("Use com.gu.pandomainauth.PublicSettings.cookieName", "0.2.7")
-  val cookieName = PublicSettings.cookieName
+)
 
-  @deprecated("Use com.gu.pandomainauth.PublicSettings.assymCookieName", "0.2.7")
-  val assymCookieName = PublicSettings.assymCookieName
-}
+case class CookieSettings(
+  cookieName: String,
+  assymCookieName: String
+)
 
 case class GoogleAuthSettings(
   googleAuthClient: String,
@@ -31,6 +31,10 @@ case class Google2FAGroupSettings(
 object PanDomainAuthSettings{
 
   def apply(settingMap: Map[String, String]): PanDomainAuthSettings = {
+    val cookieSettings = CookieSettings(
+      cookieName = settingMap("cookieName"),
+      assymCookieName = settingMap("assymCookieName")
+    )
 
     val googleAuthSettings = GoogleAuthSettings(settingMap("googleAuthClientId"), settingMap("googleAuthSecret"))
 
@@ -43,6 +47,13 @@ object PanDomainAuthSettings{
       Google2FAGroupSettings(serviceAccountId, serviceAccountCert, adminUser, group)
     }
 
-    PanDomainAuthSettings(Secret(settingMap("secret")), PublicKey(settingMap("publicKey")), PrivateKey(settingMap("privateKey")), googleAuthSettings, google2faSettings)
+    PanDomainAuthSettings(
+      Secret(settingMap("secret")),
+      PublicKey(settingMap("publicKey")),
+      PrivateKey(settingMap("privateKey")),
+      cookieSettings,
+      googleAuthSettings,
+      google2faSettings
+    )
   }
 }

--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/PanDomainAuthSettings.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/PanDomainAuthSettings.scala
@@ -7,7 +7,7 @@ case class PanDomainAuthSettings(
   publicKey: PublicKey,
   privateKey: PrivateKey,
   cookieSettings: CookieSettings,
-  googleAuthSettings: GoogleAuthSettings,
+  oAuthSettings: OAuthSettings,
   google2FAGroupSettings: Option[Google2FAGroupSettings]
 )
 
@@ -16,9 +16,10 @@ case class CookieSettings(
   assymCookieName: String
 )
 
-case class GoogleAuthSettings(
-  googleAuthClient: String,
-  googleAuthSecret: String
+case class OAuthSettings(
+  clientId: String,
+  clientSecret: String,
+  discoveryDocumentUrl: String
 )
 
 case class Google2FAGroupSettings(
@@ -36,7 +37,11 @@ object PanDomainAuthSettings{
       assymCookieName = settingMap("assymCookieName")
     )
 
-    val googleAuthSettings = GoogleAuthSettings(settingMap("googleAuthClientId"), settingMap("googleAuthSecret"))
+    val oAuthSettings = OAuthSettings(
+      settingMap("clientId"),
+      settingMap("clientSecret"),
+      settingMap("discoveryDocumentUrl")
+    )
 
     val google2faSettings = for(
       serviceAccountId   <- settingMap.get("googleServiceAccountId");
@@ -52,7 +57,7 @@ object PanDomainAuthSettings{
       PublicKey(settingMap("publicKey")),
       PrivateKey(settingMap("privateKey")),
       cookieSettings,
-      googleAuthSettings,
+      oAuthSettings,
       google2faSettings
     )
   }

--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/PanDomainAuthSettings.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/PanDomainAuthSettings.scala
@@ -12,7 +12,7 @@ case class PanDomainAuthSettings(
 )
 
 case class CookieSettings(
-  cookieName: String,
+  legacyCookieName: String,
   assymCookieName: String
 )
 
@@ -33,7 +33,7 @@ object PanDomainAuthSettings{
 
   def apply(settingMap: Map[String, String]): PanDomainAuthSettings = {
     val cookieSettings = CookieSettings(
-      cookieName = settingMap("cookieName"),
+      legacyCookieName = settingMap("legacyCookieName"),
       assymCookieName = settingMap("assymCookieName")
     )
 

--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/service/S3Bucket.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/service/S3Bucket.scala
@@ -4,12 +4,13 @@ import java.util.Properties
 
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.s3.model.GetObjectRequest
 
 import scala.collection.JavaConverters._
 
-class S3Bucket(bucketName: String, credentialsProvider: AWSCredentialsProvider, region: String, proxyConfiguration: Option[ProxyConfiguration] = None) {
+class S3Bucket(bucketName: String, credentialsProvider: AWSCredentialsProvider, region: Regions, proxyConfiguration: Option[ProxyConfiguration] = None) {
   val s3Client = AmazonS3ClientBuilder.standard().withRegion(region).withCredentials(credentialsProvider).build()
 
   def readDomainSettings(domain: String): Map[String, String] = {

--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/service/S3Bucket.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/service/S3Bucket.scala
@@ -1,21 +1,16 @@
 package com.gu.pandomainauth.service
 
 import java.util.Properties
-import com.amazonaws.ClientConfiguration
-import com.amazonaws.regions.{Regions, Region}
-import com.gu.pandomainauth.PublicSettings
 
-import scala.collection.JavaConverters._
+import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.s3.model.GetObjectRequest
 
-class S3Bucket(credentialsProvider: AWSCredentialsProvider, regionOption: Option[Region] = None, proxyConfiguration: Option[ProxyConfiguration] = None) {
+import scala.collection.JavaConverters._
 
-  val region = regionOption getOrElse (Region getRegion Regions.EU_WEST_1)
-  val s3Client = region.createClient(classOf[AmazonS3Client], credentialsProvider, awsClientConfiguration)
-
-  val bucketName = PublicSettings.bucketName
+class S3Bucket(bucketName: String, credentialsProvider: AWSCredentialsProvider, region: String, proxyConfiguration: Option[ProxyConfiguration] = None) {
+  val s3Client = AmazonS3ClientBuilder.standard().withRegion(region).withCredentials(credentialsProvider).build()
 
   def readDomainSettings(domain: String): Map[String, String] = {
 

--- a/pan-domain-auth-example/app/controllers/AdminController.scala
+++ b/pan-domain-auth-example/app/controllers/AdminController.scala
@@ -20,7 +20,7 @@ class AdminController(
   }
 
   def oauthCallback = Action.async { implicit request =>
-    processGoogleCallback()
+    processOAuthCallback()
   }
 
   def logout = Action { implicit request =>

--- a/pan-domain-auth-example/app/controllers/ExampleAuthActions.scala
+++ b/pan-domain-auth-example/app/controllers/ExampleAuthActions.scala
@@ -16,5 +16,5 @@ trait ExampleAuthActions extends AuthActions {
 
   override def cacheValidation = false
 
-  override def authCallbackUrl: String = config.get[String]("host") + "/oauthCallback"
+  override def authCallbackUrl: String = "https://" + config.get[String]("host") + "/oauthCallback"
 }

--- a/pan-domain-auth-example/app/di.scala
+++ b/pan-domain-auth-example/app/di.scala
@@ -1,5 +1,4 @@
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import controllers.AdminController
 import play.api.ApplicationLoader.Context
@@ -24,20 +23,14 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   // Change this to point to the S3 bucket containing the settings file
   val bucketName = "pan-domain-auth-settings"
 
-  // Prefer profile credentials over static credentials
-  // If you work at the Guardian you can get these credentials from Janus
-  val awsCredentialsProvider = new AWSCredentialsProviderChain(
-    new ProfileCredentialsProvider("workflow"),
-    DefaultAWSCredentialsProviderChain.getInstance()
-  )
-
   val panDomainSettings = new PanDomainAuthSettingsRefresher(
     domain = "local.dev-gutools.co.uk",
     system = "example",
     bucketName = bucketName,
     actorSystem = actorSystem,
     awsRegion = awsRegion,
-    awsCredentialsProvider = awsCredentialsProvider
+    // Customise as appropriate depending on how you manage your AWS credentials
+    awsCredentialsProvider = DefaultAWSCredentialsProviderChain.getInstance()
   )
 
   val controller = new AdminController(controllerComponents, configuration, wsClient, panDomainSettings)

--- a/pan-domain-auth-example/app/di.scala
+++ b/pan-domain-auth-example/app/di.scala
@@ -1,11 +1,11 @@
-import com.amazonaws.auth.BasicAWSCredentials
-import com.amazonaws.internal.StaticCredentialsProvider
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import controllers.AdminController
-import play.api.{Application, ApplicationLoader, BuiltInComponentsFromContext}
 import play.api.ApplicationLoader.Context
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.routing.Router
+import play.api.{Application, ApplicationLoader, BuiltInComponentsFromContext}
 import play.filters.HttpFiltersComponents
 import router.Routes
 
@@ -19,15 +19,24 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   with AhcWSComponents
   with HttpFiltersComponents {
 
-  val awsCredentialsProvider = new StaticCredentialsProvider(new BasicAWSCredentials(
-    configuration.get[String]("aws.keyId"),
-    configuration.get[String]("aws.secret")
-  ))
+  val awsRegion = "eu-west-1"
+
+  // Change this to point to the S3 bucket containing the settings file
+  val bucketName = "pan-domain-auth-settings"
+
+  // Prefer profile credentials over static credentials
+  // If you work at the Guardian you can get these credentials from Janus
+  val awsCredentialsProvider = new AWSCredentialsProviderChain(
+    new ProfileCredentialsProvider("workflow"),
+    DefaultAWSCredentialsProviderChain.getInstance()
+  )
 
   val panDomainSettings = new PanDomainAuthSettingsRefresher(
     domain = "local.dev-gutools.co.uk",
     system = "example",
+    bucketName = bucketName,
     actorSystem = actorSystem,
+    awsRegion = awsRegion,
     awsCredentialsProvider = awsCredentialsProvider
   )
 

--- a/pan-domain-auth-example/app/di.scala
+++ b/pan-domain-auth-example/app/di.scala
@@ -1,4 +1,5 @@
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.regions.Regions
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import controllers.AdminController
 import play.api.ApplicationLoader.Context
@@ -18,8 +19,6 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   with AhcWSComponents
   with HttpFiltersComponents {
 
-  val awsRegion = "eu-west-1"
-
   // Change this to point to the S3 bucket containing the settings file
   val bucketName = "pan-domain-auth-settings"
 
@@ -28,7 +27,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
     system = "example",
     bucketName = bucketName,
     actorSystem = actorSystem,
-    awsRegion = awsRegion,
+    awsRegion = Regions.EU_WEST_1,
     // Customise as appropriate depending on how you manage your AWS credentials
     awsCredentialsProvider = DefaultAWSCredentialsProviderChain.getInstance()
   )

--- a/pan-domain-auth-example/cognito.yaml
+++ b/pan-domain-auth-example/cognito.yaml
@@ -1,7 +1,16 @@
 AWSTemplateFormatVersion: '2010-09-09'
 
 Description: >
-  Panda example Cognito user pool. Users are added by email address.
+  Panda example Cognito user pool. The following are required fields for users:
+    - email (used as the "identity" of the user, there are no separate usernames
+    - name
+    - given_name
+    - family_name
+
+  The following fields are optional:
+    - profile
+    - picture
+    - locale
 
 Parameters:
   Name:
@@ -23,6 +32,33 @@ Resources:
       UsernameAttributes:
         - email
       UserPoolName: !Ref Name
+      # https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+      Schema:
+      - Name: name
+        AttributeDataType: String
+        Mutable: true
+        Required: true
+      - Name: given_name
+        AttributeDataType: String
+        Mutable: true
+        Required: true
+      - Name: family_name
+        AttributeDataType: String
+        Mutable: true
+        Required: true
+      # optional
+      - Name: profile
+        AttributeDataType: String
+        Mutable: true
+        Required: false
+      - Name: picture
+        AttributeDataType: String
+        Mutable: true
+        Required: false
+      - Name: locale
+        AttributeDataType: String
+        Mutable: true
+        Required: false
 
   UserPoolClient:
     Type: AWS::Cognito::UserPoolClient

--- a/pan-domain-auth-example/cognito.yaml
+++ b/pan-domain-auth-example/cognito.yaml
@@ -1,0 +1,34 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: >
+  Panda example Cognito user pool. Users are added by email address.
+
+Parameters:
+  Name:
+    Type: String
+    Description: The name of the user pool
+
+  RefreshTokenValidity:
+    Type: Number
+    Description: The time limit, in days, after which the refresh token is no longer valid.
+
+Resources:
+  UserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      AdminCreateUserConfig:
+        AllowAdminCreateUserOnly: true
+      AutoVerifiedAttributes:
+        - email
+      UsernameAttributes:
+        - email
+      UserPoolName: !Ref Name
+
+  UserPoolClient:
+    Type: AWS::Cognito::UserPoolClient
+    Properties:
+      ExplicitAuthFlows:
+        - USER_PASSWORD_AUTH
+      GenerateSecret: true
+      RefreshTokenValidity: !Ref RefreshTokenValidity
+      UserPoolId: !Ref UserPool

--- a/pan-domain-auth-example/conf/application.conf
+++ b/pan-domain-auth-example/conf/application.conf
@@ -22,11 +22,5 @@ logger.play=DEBUG
 # Logger provided to your application:
 logger.application=DEBUG
 
-host=${?HOST}
-
-aws {
-  keyId = ${?AWS_ACCESS_KEY}
-  secret = ${?AWS_SECRET}
-}
-
-include "local.conf"
+host="example.local.dev-gutools.co.uk"
+play.filters.hosts.allowed = ["example.local.dev-gutools.co.uk", "example.code.dev-gutools.co.uk", "example.gutools.co.uk"]

--- a/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -165,7 +165,7 @@ trait AuthActions {
 
   def generateCookies(authedUser: AuthenticatedUser): List[Cookie] = List(
     Cookie(
-      name = settings.cookieSettings.cookieName,
+      name = settings.cookieSettings.legacyCookieName,
       value = LegacyCookie.generateCookieData(authedUser, settings.secret),
       domain = Some(domain),
       secure = true,
@@ -188,7 +188,7 @@ trait AuthActions {
 
   def flushCookie(result: Result): Result = {
     val clearCookie = DiscardingCookie(
-      name = settings.cookieSettings.cookieName,
+      name = settings.cookieSettings.legacyCookieName,
       domain = Some(domain),
       secure = true
     )

--- a/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -161,18 +161,18 @@ trait AuthActions {
     CookieUtils.parseCookieData(cookie.value, settings.publicKey)
   }
 
-  def readCookie(request: RequestHeader): Option[Cookie] = request.cookies.get(PublicSettings.assymCookieName)
+  def readCookie(request: RequestHeader): Option[Cookie] = request.cookies.get(settings.cookieSettings.assymCookieName)
 
   def generateCookies(authedUser: AuthenticatedUser): List[Cookie] = List(
     Cookie(
-      name = PublicSettings.cookieName,
+      name = settings.cookieSettings.cookieName,
       value = LegacyCookie.generateCookieData(authedUser, settings.secret),
       domain = Some(domain),
       secure = true,
       httpOnly = true
     ),
     Cookie(
-      name = PublicSettings.assymCookieName,
+      name = settings.cookieSettings.assymCookieName,
       value = CookieUtils.generateCookieData(authedUser, settings.privateKey),
       domain = Some(domain),
       secure = true,
@@ -188,12 +188,12 @@ trait AuthActions {
 
   def flushCookie(result: Result): Result = {
     val clearCookie = DiscardingCookie(
-      name = PublicSettings.cookieName,
+      name = settings.cookieSettings.cookieName,
       domain = Some(domain),
       secure = true
     )
     val clearAssymCookie = DiscardingCookie(
-      name = PublicSettings.assymCookieName,
+      name = settings.cookieSettings.assymCookieName,
       domain = Some(domain),
       secure = true
     )

--- a/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -42,7 +42,7 @@ trait AuthActions {
     * By default the validity of the user is checked every request. If your validateUser implementation is expensive or has side effects you
     * can override this to true and validity will only be checked the first time the user visits your app after their login is established.
     *
-    * Note the the cache is invalidated after the user's session is re-established with google.
+    * Note the the cache is invalidated after the user's session is re-established with the OAuth provider.
     *
     * @return true if you want to only check the validity of the user once for the lifetime of the user's auth session
     */
@@ -61,14 +61,14 @@ trait AuthActions {
   def apiGracePeriod: Long = 0 // ms
 
   /**
-    * The auth callback url. This is where google will send the user after authentication. This action on this url should
-    * invoke processGoogleCallback
+    * The auth callback url. This is where the OAuth provider will send the user after authentication.
+    * This action on should invoke processOAuthCallback
     *
     * @return
     */
   def authCallbackUrl: String
 
-  val GoogleAuth = new GoogleAuth(settings.googleAuthSettings, system, authCallbackUrl)
+  val OAuth = new OAuth(settings.oAuthSettings, system, authCallbackUrl)
 
   val multifactorChecker: Option[Google2FAGroupChecker] = settings.google2FAGroupSettings.map(new Google2FAGroupChecker(_, panDomainSettings.bucket))
 
@@ -81,12 +81,12 @@ trait AuthActions {
   val ANTI_FORGERY_KEY = "antiForgeryToken"
 
   /**
-    * starts the authentication process for a user. By default this just sends the user off to google for auth
+    * starts the authentication process for a user. By default this just sends the user off to the OAuth provider for auth
     * but if you want to show welcome page with a button on it then override.
     */
   def sendForAuth[A](implicit request: RequestHeader, email: Option[String] = None) = {
-    val antiForgeryToken = GoogleAuth.generateAntiForgeryToken()
-    GoogleAuth.redirectToGoogle(antiForgeryToken, email)(ec, request, wsClient) map { res =>
+    val antiForgeryToken = OAuth.generateAntiForgeryToken()
+    OAuth.redirectToOAuthProvider(antiForgeryToken, email)(ec, request, wsClient) map { res =>
       val originUrl = request.uri
       res.withSession { request.session + (ANTI_FORGERY_KEY -> antiForgeryToken) + (LOGIN_ORIGIN_KEY -> originUrl) }
     }
@@ -118,15 +118,15 @@ trait AuthActions {
     */
   def invalidUserMessage(claimedAuth: AuthenticatedUser) = s"user ${claimedAuth.user.email} not valid for $system"
 
-  def processGoogleCallback()(implicit request: RequestHeader) = {
+  def processOAuthCallback()(implicit request: RequestHeader) = {
     val token =
-      request.session.get(ANTI_FORGERY_KEY).getOrElse(throw new GoogleAuthException("missing anti forgery token"))
+      request.session.get(ANTI_FORGERY_KEY).getOrElse(throw new OAuthException("missing anti forgery token"))
     val originalUrl =
-      request.session.get(LOGIN_ORIGIN_KEY).getOrElse(throw new GoogleAuthException("missing original url"))
+      request.session.get(LOGIN_ORIGIN_KEY).getOrElse(throw new OAuthException("missing original url"))
 
     val existingCookie = readCookie(request) // will be populated if this was a re-auth for expired login
 
-    GoogleAuth.validatedUserIdentity(token)(request, ec, wsClient).map { claimedAuth =>
+    OAuth.validatedUserIdentity(token)(request, ec, wsClient).map { claimedAuth =>
       val authedUserData = existingCookie match {
         case Some(c) =>
           val existingAuth = CookieUtils.parseCookieData(c.value, settings.publicKey)

--- a/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -205,7 +205,7 @@ trait AuthActions {
     */
   def extractAuth(request: RequestHeader): AuthenticationStatus = {
     readCookie(request).map { cookie =>
-      PanDomain.authStatus(cookie.value, settings.publicKey) match {
+      PanDomain.authStatus(cookie.value, settings.publicKey, validateUser) match {
         case Expired(authedUser) if authedUser.isInGracePeriod(apiGracePeriod) =>
           GracePeriod(authedUser)
         case authStatus @ Authenticated(authedUser) =>

--- a/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/service/oAuthModel.scala
+++ b/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/service/oAuthModel.scala
@@ -7,7 +7,6 @@ import org.apache.commons.codec.binary.Base64
 
 case class DiscoveryDocument(authorization_endpoint: String, token_endpoint: String, userinfo_endpoint: String)
 object DiscoveryDocument {
-  val url = "https://accounts.google.com/.well-known/openid-configuration"
   implicit val discoveryDocumentReads = Json.reads[DiscoveryDocument]
   def fromJson(json: JsValue) = Json.fromJson[DiscoveryDocument](json).getOrElse(
     throw new IllegalArgumentException("Invalid discovery document")

--- a/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/service/oAuthModel.scala
+++ b/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/service/oAuthModel.scala
@@ -30,14 +30,14 @@ object Token {
   }
 }
 
-case class JwtClaims(iss: String, sub:String, azp: String, email: String, at_hash: String, email_verified: Boolean,
+case class JwtClaims(iss: String, sub: String, azp: Option[String], email: String, at_hash: String, email_verified: Boolean,
                      aud: String, hd: Option[String], iat: Long, exp: Long)
 object JwtClaims {
   implicit val claimsReads = Json.reads[JwtClaims]
 }
 
-case class UserInfo(gender: Option[String], sub: Option[String], name: String, given_name: String, family_name: String,
-                    profile: Option[String], picture: Option[String], email: String, locale: Option[String], hd: Option[String])
+case class UserInfo(sub: Option[String], name: String, given_name: String, family_name: String, profile: Option[String],
+                    picture: Option[String], email: String, locale: Option[String], hd: Option[String])
 object UserInfo {
   implicit val userInfoReads = Json.reads[UserInfo]
 

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PanDomain.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PanDomain.scala
@@ -8,7 +8,7 @@ object PanDomain {
   /**
    * Check the authentication status of the provided credentials by examining the signed cookie data.
    */
-  def authStatus(cookieData: String, publicKey: PublicKey, validateUser: AuthenticatedUser => Boolean = guardianValidation): AuthenticationStatus = {
+  def authStatus(cookieData: String, publicKey: PublicKey, validateUser: AuthenticatedUser => Boolean): AuthenticationStatus = {
     try {
       val authedUser = CookieUtils.parseCookieData(cookieData, publicKey)
       checkStatus(authedUser, validateUser)
@@ -18,7 +18,7 @@ object PanDomain {
     }
   }
 
-  private def checkStatus(authedUser: AuthenticatedUser, validateUser: AuthenticatedUser => Boolean = guardianValidation): AuthenticationStatus = {
+  private def checkStatus(authedUser: AuthenticatedUser, validateUser: AuthenticatedUser => Boolean): AuthenticationStatus = {
     if (authedUser.isExpired) {
       Expired(authedUser)
     } else if (validateUser(authedUser)) {

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PublicSettings.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PublicSettings.scala
@@ -24,14 +24,16 @@ import scala.util.Try
  * you'd rather use your own scheduler you can do so while still using the PublicSettings class by scheduling
  * your own calls to its `refresh` method can also schdule the refresh yourself using the instance's
  *
- * @param domain    The domain you would like to fetch settings for
- * @param callback  Optionally, a callback called when the data gets fetched, provided to allow you to perform logging
- * @param scheduler Optionally, the quartz scheduler instance to use. It defaults to the default scheduler but
- *                  customising it may be useful if you want more control over the scheduler's lifecycle
- * @param client    Implicit instance of dispatch.Http used to make the call to fetch the public settings
- * @param ec        Implicit execution context used to fetch the settings
+ * @param domain     The domain you would like to fetch settings for
+ * @param callback   Optionally, a callback called when the data gets fetched, provided to allow you to perform logging
+ * @param bucketName The name of the S3 bucket
+ * @param scheduler  Optionally, the quartz scheduler instance to use. It defaults to the default scheduler but
+ *                   customising it may be useful if you want more control over the scheduler's lifecycle
+ * @param client     Implicit instance of dispatch.Http used to make the call to fetch the public settings
+ * @param ec         Implicit execution context used to fetch the settings
  */
-class PublicSettings(domain: String, callback: Try[Map[String, String]] => Unit = _ => (), scheduler: Scheduler = StdSchedulerFactory.getDefaultScheduler())
+class PublicSettings(domain: String, bucketName: String, callback: Try[Map[String, String]] => Unit = _ => (),
+                     scheduler: Scheduler = StdSchedulerFactory.getDefaultScheduler())
                     (implicit client: OkHttpClient, ec: ExecutionContext) {
 
   private val agent = Agent[Map[String, String]](Map.empty)
@@ -63,7 +65,7 @@ class PublicSettings(domain: String, callback: Try[Map[String, String]] => Unit 
     scheduler.deleteJob(job.getKey)
   }
   def refresh() = {
-    val publicFuture = PublicSettings.getPublicSettings(domain)
+    val publicFuture = PublicSettings.getPublicSettings(domain, bucketName)
     publicFuture
       .onComplete(callback)
     publicFuture
@@ -71,9 +73,6 @@ class PublicSettings(domain: String, callback: Try[Map[String, String]] => Unit 
   }
 
   def publicKey = agent.get().get("publicKey")
-  val bucketName = PublicSettings.bucketName
-  val cookieName = PublicSettings.cookieName
-  val assymCookieName = PublicSettings.assymCookieName
 }
 
 /**
@@ -81,12 +80,8 @@ class PublicSettings(domain: String, callback: Try[Map[String, String]] => Unit 
  * public data.
  */
 object PublicSettings {
-  val bucketName = sys.env.getOrElse("PANDA_BUCKET_NAME", "pan-domain-auth-settings")
-  val cookieName = "gutoolsAuth"
-  val assymCookieName = s"$cookieName-assym"
-
-  def getPublicSettings(domain: String)(implicit client: OkHttpClient, ec: ExecutionContext): Future[Map[String, String]] = {
-    fetchSettings(domain) flatMap extractSettings
+  def getPublicSettings(domain: String, bucketName: String)(implicit client: OkHttpClient, ec: ExecutionContext): Future[Map[String, String]] = {
+    fetchSettings(domain, bucketName) flatMap extractSettings
   }
 
   /**
@@ -96,12 +91,12 @@ object PublicSettings {
    * @param client implicit dispatch.Http to use for fetching the key
    * @param ec     implicit execution context to use for fetching the key
    */
-  def getPublicKey(domain: String)(implicit client: OkHttpClient, ec: ExecutionContext): Future[PublicKey] = {
-    getPublicSettings(domain) flatMap extractPublicKey
+  def getPublicKey(domain: String, bucketName: String)(implicit client: OkHttpClient, ec: ExecutionContext): Future[PublicKey] = {
+    getPublicSettings(domain, bucketName) flatMap extractPublicKey
   }
 
   // internal functions for fetching and parsing the responses
-  private def fetchSettings(domain: String)(implicit client: OkHttpClient, ec: ExecutionContext): Future[Either[Throwable, String]] = {
+  private def fetchSettings(domain: String, bucketName: String)(implicit client: OkHttpClient, ec: ExecutionContext): Future[Either[Throwable, String]] = {
     val promise = Promise[Either[Throwable, String]]()
     val req = new Request.Builder().url(s"https://s3-eu-west-1.amazonaws.com/$bucketName/$domain.settings.public").build()
 

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PublicSettings.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PublicSettings.scala
@@ -26,7 +26,7 @@ import scala.util.Try
  *
  * @param domain     The domain you would like to fetch settings for
  * @param callback   Optionally, a callback called when the data gets fetched, provided to allow you to perform logging
- * @param bucketName The name of the S3 bucket
+ * @param bucketName The name of the S3 bucket where the settings are stored
  * @param scheduler  Optionally, the quartz scheduler instance to use. It defaults to the default scheduler but
  *                   customising it may be useful if you want more control over the scheduler's lifecycle
  * @param client     Implicit instance of dispatch.Http used to make the call to fetch the public settings

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
 
-  val awsDependencies = Seq("com.amazonaws" % "aws-java-sdk-s3" % "1.11.8")
+  val awsDependencies = Seq("com.amazonaws" % "aws-java-sdk-s3" % "1.11.461")
 
   val akkaDependencies = Seq("com.typesafe.akka" %% "akka-agent" % "2.4.20")
 


### PR DESCRIPTION
Adds the ability to configure the OAuth discovery document and therefore use Panda with OAuth providers that are not google.

We were unfortunately hard-coding the `validateUser` function when [checking the auth status](https://github.com/guardian/pan-domain-authentication/blob/68db57f487073af2bf5f9081926873cc1b8aef83/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PanDomain.scala). This is now customisable correctly. 

The rationale for the change is to allow non-Guardian developers to set up and evaluate the [Grid](http://github.com/guardian/grid) using a [Cognito user pool](https://docs.aws.amazon.com/cognito/latest/developerguide/getting-started-with-cognito-user-pools.html) rather than setting up a Google API project. In the future they can use Cognito to delegate to any auth provider using SAML.

I've also added an example Cognito user pool CloudFormation template.

This is a breaking change:

- The calling code must now specify the Panda bucket name, `AWSCredentialsProvider`, `region` directly
   - This avoids other users defaulting to the Guardian bucket
   - It was possible to use an environment variable to customise it. This is now the responsibility of the calling code
   - This avoids us including static credentials in the examples since we no longer recommend them at the Guardian

- Rename `googleId` and `googleClientSecret` to `clientId` and `clientSecret`

- The name of the cookies must be set in configuration. For example:
  - `legacyCookieName`: `gutoolsAuth`
  - `assymCookieName`: `gutoolsAuth-assym`


- `discoveryDocumentUrl` must be set in configuration
  - Google: `https://accounts.google.com/.well-known/openid-configuration`
  - Example Cognito: `https://cognito-idp.eu-west-1.amazonaws.com/eu-west-1_nW3FKqRh0/.well-known/openid-configuration`