### PR TITLE
Update bouncy castle to latest version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   )
 
   val cryptoDependencies = Seq(
-    "org.bouncycastle" % "bcprov-jdk15on" % "1.58",
+    "org.bouncycastle" % "bcprov-jdk15on" % "1.60",
     "commons-codec" % "commons-codec" % "1.10"
   )
 


### PR DESCRIPTION
@guardian/digital-cms

Current version is vulnerable to Insecure Encryption. It has a flaw in the Low-level interface to RSA key pair generator, specifically RSA Key Pairs generated in low-level API with added certainty may have less M-R tests than expected.

[CVE](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000180)