### PR TITLE
Bump Jackson to fix a tonne of vulnerabities

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,7 +39,7 @@ object Dependencies {
   * See https://github.com/aws/aws-sdk-java/pull/1373
   * */
   val jackson: Seq[ModuleID] = {
-    val version = "2.9.2"
+    val version = "2.9.8"
     Seq(
       "com.fasterxml.jackson.core" % "jackson-core" % version,
       "com.fasterxml.jackson.core" % "jackson-databind" % version,


### PR DESCRIPTION
I don't think any of these are actually in the path of the calling-code in Panda but best to get them upgrade entirely, especially when there's nasty things in there like Mad Gadget.

https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72884
https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72882
https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72882
https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72451
https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72450
https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72449
https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72448
https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72447
https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72883
https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72445
https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72446


@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->