### PR TITLE
This fixes a couple of problems with the validation logic (v2)

### DIFF
--- a/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -205,15 +205,7 @@ trait AuthActions {
     */
   def extractAuth(request: RequestHeader): AuthenticationStatus = {
     readCookie(request).map { cookie =>
-      PanDomain.authStatus(cookie.value, settings.publicKey, validateUser) match {
-        case Expired(authedUser) if authedUser.isInGracePeriod(apiGracePeriod) =>
-          GracePeriod(authedUser)
-        case authStatus @ Authenticated(authedUser) =>
-          if (cacheValidation && authedUser.authenticatedIn(system)) authStatus
-          else if (validateUser(authedUser)) authStatus
-          else NotAuthorized(authedUser)
-        case authStatus => authStatus
-      }
+      PanDomain.authStatus(cookie.value, settings.publicKey, validateUser, apiGracePeriod, system, cacheValidation)
     } getOrElse NotAuthenticated
   }
 

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PanDomain.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PanDomain.scala
@@ -1,29 +1,50 @@
 package com.gu.pandomainauth
 
 import com.gu.pandomainauth.model._
-import com.gu.pandomainauth.service.{LegacyCookie, CookieUtils}
+import com.gu.pandomainauth.service.CookieUtils
 
 
 object PanDomain {
   /**
    * Check the authentication status of the provided credentials by examining the signed cookie data.
    */
-  def authStatus(cookieData: String, publicKey: PublicKey, validateUser: AuthenticatedUser => Boolean): AuthenticationStatus = {
+  def authStatus(cookieData: String, publicKey: PublicKey, validateUser: AuthenticatedUser => Boolean,
+                 apiGracePeriod: Long, system: String, cacheValidation: Boolean): AuthenticationStatus = {
     try {
       val authedUser = CookieUtils.parseCookieData(cookieData, publicKey)
-      checkStatus(authedUser, validateUser)
+      checkStatus(authedUser, validateUser, apiGracePeriod, system, cacheValidation)
     } catch {
       case e: Exception =>
         InvalidCookie(e)
     }
   }
 
-  private def checkStatus(authedUser: AuthenticatedUser, validateUser: AuthenticatedUser => Boolean): AuthenticationStatus = {
-    if (authedUser.isExpired) {
+  private def checkStatus(authedUser: AuthenticatedUser, validateUser: AuthenticatedUser => Boolean,
+                          apiGracePeriod: Long, system: String, cacheValidation: Boolean): AuthenticationStatus = {
+
+    if (authedUser.isExpired && authedUser.isInGracePeriod(apiGracePeriod)) {
+      // expired, but in grace period - check user is valid, GracePeriod if so
+      if (cacheValidation && authedUser.authenticatedIn(system)) {
+        // if validation is cached, check user has been validated here
+        GracePeriod(authedUser)
+      } else if (validateUser(authedUser)) {
+        // validation says this user is ok
+        GracePeriod(authedUser)
+      } else {
+        // the user is in the grace period but has failed validation
+        NotAuthorized(authedUser)
+      }
+    } else if (authedUser.isExpired) {
+      // expired and outside grace period
       Expired(authedUser)
+    } else if (cacheValidation && authedUser.authenticatedIn(system)) {
+      // if cacheValidation is enabled, check the user was validated here
+      Authenticated(authedUser)
     } else if (validateUser(authedUser)) {
+      // fresh validation says the user is valid
       Authenticated(authedUser)
     } else {
+      // user has not expired but has failed validation checks
       NotAuthorized(authedUser)
     }
   }

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/PanDomainTest.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/PanDomainTest.scala
@@ -3,50 +3,107 @@ package com.gu.pandomainauth
 import java.util.Date
 
 import com.gu.pandomainauth.model._
-import com.gu.pandomainauth.service.{LegacyCookie, CookieUtils}
-import org.scalatest.{Inside, Matchers, FreeSpec}
+import com.gu.pandomainauth.service.CookieUtils
+import org.scalatest.{FreeSpec, Inside, Matchers}
 
 class PanDomainTest extends FreeSpec with Matchers with Inside {
   import com.gu.pandomainauth.service.TestKeys._
 
+  def authStatus(cookieData: String, validateUser: AuthenticatedUser => Boolean = _ => true, apiGracePeriod: Long = 0,
+                 system: String = "testsuite", cacheValidation: Boolean = false) = {
+    PanDomain.authStatus(cookieData, testPublicKey, validateUser, apiGracePeriod, system, cacheValidation)
+  }
+
   "authStatus" - {
     val authUser = AuthenticatedUser(User("test", "user", "test.user@example.com", None), "testsuite", Set("testsuite"), new Date().getTime + 86400, multiFactor = true)
+    val validCookieData = CookieUtils.generateCookieData(authUser, testPrivateKey)
 
     "returns `Authenticated` for valid cookie data that passes the validation check" in {
       def validateUser(au: AuthenticatedUser): Boolean = au.multiFactor && au.user.emailDomain == "example.com"
       val cookieData = CookieUtils.generateCookieData(authUser, testPrivateKey)
 
-      PanDomain.authStatus(cookieData, testPublicKey, validateUser) shouldBe a [Authenticated]
+      authStatus(cookieData, validateUser) shouldBe a [Authenticated]
     }
 
     "gives back the provided auth user if successful" in {
       val cookieData = CookieUtils.generateCookieData(authUser, testPrivateKey)
 
-      PanDomain.authStatus(cookieData, testPublicKey, _ => true) should equal(Authenticated(authUser))
+      authStatus(cookieData) should equal(Authenticated(authUser))
     }
 
     "returns `InvalidCookie` if the cookie is not valid" in {
-      PanDomain.authStatus("invalid cookie data", testPublicKey, _ => true) shouldBe a [InvalidCookie]
+      authStatus("invalid cookie data") shouldBe a [InvalidCookie]
     }
 
     "returns `InvalidCookie` if the cookie fails its signature check" in {
       val incorrectCookieData = CookieUtils.generateCookieData(authUser, testINCORRECTPrivateKey)
 
-      PanDomain.authStatus(incorrectCookieData, testPublicKey, _ => true) shouldBe a [InvalidCookie]
+      authStatus(incorrectCookieData) shouldBe a [InvalidCookie]
     }
 
     "returns `Expired` if the time is after the cookie's expiry" in {
       val expiredAuthUser = authUser.copy(expires = new Date().getTime - 86400)
       val cookieData = CookieUtils.generateCookieData(expiredAuthUser, testPrivateKey)
 
-      PanDomain.authStatus(cookieData, testPublicKey, _ => true) shouldBe a [Expired]
+      authStatus(cookieData) shouldBe a [Expired]
+    }
+
+    "returns `Expired` if the cookie has expired and is outside the grace period" in {
+      val expiredAuthUser = authUser.copy(expires = new Date().getTime - 86400)
+      val cookieData = CookieUtils.generateCookieData(expiredAuthUser, testPrivateKey)
+
+      authStatus(cookieData) shouldBe a [Expired]
+    }
+
+    "returns `GracePeriod` if the cookie has expired but is within the grace period" in {
+      val expiredAuthUser = authUser.copy(expires = new Date().getTime - 3000)
+      val cookieData = CookieUtils.generateCookieData(expiredAuthUser, testPrivateKey)
+
+      authStatus(cookieData, apiGracePeriod = 3600) shouldBe a [GracePeriod]
     }
 
     "returns `NotAuthorized` if the cookie does not pass the verification check" in {
       def validateUser(au: AuthenticatedUser): Boolean = au.multiFactor && au.user.emailDomain == "example.com"
       val cookieData = CookieUtils.generateCookieData(authUser, testPrivateKey)
 
-      PanDomain.authStatus(cookieData, testPublicKey, _ => false) shouldBe a [NotAuthorized]
+      authStatus(cookieData, _ => false) shouldBe a [NotAuthorized]
+    }
+
+    "correctly handles the verification check" - {
+      val invalid: AuthenticatedUser => Boolean = _ => false
+      val valid: AuthenticatedUser => Boolean = _ => true
+
+      "without cache validation, " - {
+        "returns `NotAuthorized` if the user fails the validation check" in {
+          authStatus(validCookieData, _ => false) shouldBe a [NotAuthorized]
+        }
+
+        "returns `Authenticated` if the user passes the validation check" in {
+          authStatus(validCookieData, _ => true) shouldBe a [Authenticated]
+        }
+      }
+
+      "when validation is cached" - {
+        "returns `NotAuthorized` if the user is not authorized in this system" in {
+          val status = authStatus(validCookieData, invalid, system = "not-the-system", cacheValidation = true)
+          status shouldBe a [NotAuthorized]
+        }
+
+        "returns Authenticated if the user was authenticated in this system, even if they would fail the validation check" in {
+          val status = authStatus(validCookieData, invalid, cacheValidation = true)
+          status shouldBe a [Authenticated]
+        }
+
+        "does not call the validateUser function if caching is enabled" in {
+          var called = false
+          val validateUser: AuthenticatedUser => Boolean = { _ =>
+            called = true
+            false
+          }
+          authStatus(validCookieData, validateUser, cacheValidation = true)
+          called shouldEqual false
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Rebasing Adams changes from https://github.com/guardian/pan-domain-authentication/pull/34. Therefore fixes #34.

The changes are the same, apart from #45 removed the hard-coded `guardianValidation` function but as a result stopped respecting the `cacheValidation` setting, calling the validation function regardless. This PR fixes that as well as the grace period skipping validation addressed in the original PR.

Commit description:

We move auth validation logic into one place and add tests to address
the following issues:

1. the validation check was being called even if cacheValidation was set
2. users in the grace period skipped the validation checks

We now consistently apply the project-provided validateUser
function. This may cause problems for existing applications but only
in surprising cases and if the projects were already doing crazy
things.

The second problem was a potential security issue, although exploiting
it would depend on finding a project that behaves in a way we'd
probably class as "not recommended".

If the project-supplied validateUser function is impure then it's
possible that it would being to fail at some point after the original
session has been issued. For example, there might be a
session-revocation feature that returns false if the user has been
blacklisted in some way. This check would have been bypassed during
the grace period providing an attacker with a window of opportunity to
exploit a compromised session.

It's worth noting that while it's unlikely this affects any of our
projects, the pan-domain-auth library was designed to support these
use cases (this is why the `cache validation` feature
exists). Ignoring questions about whether these features make any
sense the way they are implemented in panda, this Pull Request fixes
this edge case.

@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->