### PR TITLE
Bump Google client to get newer version of Guava

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   }
 
   val googleDirectoryApiDependencies = Seq(
-    "com.google.api-client" % "google-api-client" % "1.22.0",
+    "com.google.api-client" % "google-api-client" % "1.28.0",
     "com.google.apis" % "google-api-services-admin" % "directory_v1-rev32-1.16.0-rc"
   )
 


### PR DESCRIPTION
The previous version depended on an old version of Guava that would occasionally be selected over the newer version by projects depending on Panda, causing  mayhem with NoSuchMethodErrors and things:

```
[15:11:26][Step 1/1] Exception in thread "pool-6-thread-1" java.lang.NoSuchMethodError: com.google.common.base.Preconditions.checkState(ZLjava/lang/String;Ljava/lang/Object;)V
[15:11:26][Step 1/1] 	at com.spotify.docker.client.DockerConfigReader.extractAuthJson(DockerConfigReader.java:198)
[15:11:26][Step 1/1] 	at com.spotify.docker.client.DockerConfigReader.parseDockerConfig(DockerConfigReader.java:130)
[15:11:26][Step 1/1] 	at com.spotify.docker.client.DockerConfigReader.parseDockerConfig(DockerConfigReader.java:91)
[15:11:26][Step 1/1] 	at com.spotify.docker.client.DockerConfigReader.fromConfig(DockerConfigReader.java:75)
[15:11:26][Step 1/1] 	at com.spotify.docker.client.auth.ConfigFileRegistryAuthSupplier.authFor(ConfigFileRegistryAuthSupplier.java:74)
[15:11:26][Step 1/1] 	at com.spotify.docker.client.DefaultDockerClient.pull(DefaultDockerClient.java:1287)
[15:11:26][Step 1/1] 	at com.spotify.docker.client.DefaultDockerClient.pull(DefaultDockerClient.java:1281)
[15:11:26][Step 1/1] 	at com.whisk.docker.impl.spotify.SpotifyDockerCommandExecutor.$anonfun$pullImage$1(SpotifyDockerCommandExecutor.scala:192)
[15:11:26][Step 1/1] 	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
[15:11:26][Step 1/1] 	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:658)
[15:11:26][Step 1/1] 	at scala.util.Success.$anonfun$map$1(Try.scala:255)
[15:11:26][Step 1/1] 	at scala.util.Success.map(Try.scala:213)
[15:11:26][Step 1/1] 	at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
[15:11:26][Step 1/1] 	at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
[15:11:26][Step 1/1] 	at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
[15:11:26][Step 1/1] 	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
[15:11:26][Step 1/1] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[15:11:26][Step 1/1] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[15:11:26][Step 1/1] 	at java.lang.Thread.run(Thread.java:748)
```

This version depends on Guava 22.0 which seems to be new enough not to cause problems


@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->