### PR TITLE
Don't publish example app

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -105,6 +105,9 @@ lazy val exampleApp = project("pan-domain-auth-example")
   .enablePlugins(PlayScala)
   .settings(libraryDependencies ++= (awsDependencies :+ ws))
   .dependsOn(panDomainAuthPlay_2_7)
+  .settings(
+    publishArtifact := false
+  )
 
 lazy val root = Project("pan-domain-auth-root", file(".")).aggregate(
   panDomainAuthVerification,


### PR DESCRIPTION
At the moment we can't release the library because there is no publishing repository specified for the example app. This is a error introduced when removing the `playProject` helper in #58.

I don't think we need to push the example app to Maven for others to consume so lets exclude it from publishing.