### PR TITLE
Set the application name in the google directory client so it doesn't moan

### DIFF
--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/service/Google2FAGroupChecker.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/service/Google2FAGroupChecker.scala
@@ -11,7 +11,7 @@ import com.google.api.services.admin.directory.{Directory, DirectoryScopes}
 import scala.collection.JavaConverters._
 import com.gu.pandomainauth.model.{AuthenticatedUser, Google2FAGroupSettings}
 
-class GroupChecker(config: Google2FAGroupSettings, bucketName: String, s3Client: AmazonS3) {
+class GroupChecker(config: Google2FAGroupSettings, bucketName: String, s3Client: AmazonS3, appName: String) {
   val transport = new NetHttpTransport()
   val jsonFactory = new JacksonFactory()
 
@@ -25,6 +25,7 @@ class GroupChecker(config: Google2FAGroupSettings, bucketName: String, s3Client:
     .build()
 
   val directory = new Directory.Builder(transport, jsonFactory, null)
+    .setApplicationName(appName)
     .setHttpRequestInitializer(credential).build
 
   private def loadServiceAccountPrivateKey = {
@@ -52,7 +53,7 @@ class GroupChecker(config: Google2FAGroupSettings, bucketName: String, s3Client:
   }
 }
 
-class GoogleGroupChecker(config: Google2FAGroupSettings, bucketName: String, s3Client: AmazonS3) extends GroupChecker(config, bucketName, s3Client) {
+class GoogleGroupChecker(config: Google2FAGroupSettings, bucketName: String, s3Client: AmazonS3, appName: String) extends GroupChecker(config, bucketName, s3Client, appName) {
 
   def checkGroups(authenticatedUser: AuthenticatedUser, groupIds: List[String]): Either[String, Boolean] = {
     val query = directory.groups().list().setUserKey(authenticatedUser.user.email)
@@ -62,7 +63,7 @@ class GoogleGroupChecker(config: Google2FAGroupSettings, bucketName: String, s3C
 
 }
 
-class Google2FAGroupChecker(config: Google2FAGroupSettings, bucketName: String, s3Client: AmazonS3) extends GroupChecker(config, bucketName, s3Client) {
+class Google2FAGroupChecker(config: Google2FAGroupSettings, bucketName: String, s3Client: AmazonS3, appName: String) extends GroupChecker(config, bucketName, s3Client, appName) {
 
   def checkMultifactor(authenticatedUser: AuthenticatedUser): Boolean = {
     val query = directory.groups().list().setUserKey(authenticatedUser.user.email)

--- a/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -70,9 +70,14 @@ trait AuthActions {
 
   val OAuth = new OAuth(settings.oAuthSettings, system, authCallbackUrl)
 
-  val multifactorChecker: Option[Google2FAGroupChecker] = settings.google2FAGroupSettings.map(new Google2FAGroupChecker(_, panDomainSettings.bucketName, panDomainSettings.s3Client))
+  /**
+    * Application name used for initialising Google API clients for directory group checking
+    */
+  val applicationName: String = s"pan-domain-authentication-$system"
 
-  val groupChecker: Option[GoogleGroupChecker] = settings.google2FAGroupSettings.map(new GoogleGroupChecker(_, panDomainSettings.bucketName, panDomainSettings.s3Client))
+  val multifactorChecker: Option[Google2FAGroupChecker] = settings.google2FAGroupSettings.map {
+    new Google2FAGroupChecker(_, panDomainSettings.bucketName, panDomainSettings.s3Client, applicationName)
+  }
 
   /**
     * A Play session key that stores the target URL that was being accessed when redirected for authentication

--- a/pan-domain-auth-play_2-7/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-7/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -71,9 +71,14 @@ trait AuthActions {
 
   val OAuth = new OAuth(settings.oAuthSettings, system, authCallbackUrl)
 
-  val multifactorChecker: Option[Google2FAGroupChecker] = settings.google2FAGroupSettings.map(new Google2FAGroupChecker(_, panDomainSettings.bucketName, panDomainSettings.s3Client))
+  /**
+    * Application name used for initialising Google API clients for directory group checking
+    */
+  val applicationName: String = s"pan-domain-authentication-$system"
 
-  val groupChecker: Option[GoogleGroupChecker] = settings.google2FAGroupSettings.map(new GoogleGroupChecker(_, panDomainSettings.bucketName, panDomainSettings.s3Client))
+  val multifactorChecker: Option[Google2FAGroupChecker] = settings.google2FAGroupSettings.map {
+    new Google2FAGroupChecker(_, panDomainSettings.bucketName, panDomainSettings.s3Client, applicationName)
+  }
 
   /**
     * A Play session key that stores the target URL that was being accessed when redirected for authentication


### PR DESCRIPTION
At initialisation of any panda based app we get messages saying `Application name is not set. Call Builder#setApplicationName`. This small change should fix that and unless people have customised this should be backwards compatible.

I've removed the group checker as it isn't used anywhere and seems to replicate the 2FA checker? Perhaps @mbarton might have an idea as to why it is there.

@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->