### PR TITLE
made email and email verified from jwt response optional, if not present get email from user info response

### DIFF
--- a/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/service/OAuth.scala
+++ b/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/service/OAuth.scala
@@ -85,7 +85,7 @@ class OAuth(config: OAuthSettings, system: String, redirectUrl: String) {
                   user = User(
                     userInfo.given_name,
                     userInfo.family_name,
-                    jwt.claims.email,
+                    jwt.claims.email.getOrElse(userInfo.email),
                     userInfo.picture
                   ),
                   authenticatingSystem = system,

--- a/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/service/oAuthModel.scala
+++ b/pan-domain-auth-play_2-6/src/main/scala/com/gu/pandomainauth/service/oAuthModel.scala
@@ -30,8 +30,8 @@ object Token {
   }
 }
 
-case class JwtClaims(iss: String, sub: String, azp: Option[String], email: String, at_hash: String, email_verified: Boolean,
-                     aud: String, hd: Option[String], iat: Long, exp: Long)
+case class JwtClaims(iss: String, sub: String, azp: Option[String], email: Option[String], at_hash: String,
+                     email_verified: Option[Boolean], aud: String, hd: Option[String], iat: Long, exp: Long)
 object JwtClaims {
   implicit val claimsReads = Json.reads[JwtClaims]
 }

--- a/pan-domain-auth-play_2-7/src/main/scala/com/gu/pandomainauth/service/OAuth.scala
+++ b/pan-domain-auth-play_2-7/src/main/scala/com/gu/pandomainauth/service/OAuth.scala
@@ -85,7 +85,7 @@ class OAuth(config: OAuthSettings, system: String, redirectUrl: String) {
                   user = User(
                     userInfo.given_name,
                     userInfo.family_name,
-                    jwt.claims.email,
+                    jwt.claims.email.getOrElse(userInfo.email),
                     userInfo.picture
                   ),
                   authenticatingSystem = system,

--- a/pan-domain-auth-play_2-7/src/main/scala/com/gu/pandomainauth/service/oAuthModel.scala
+++ b/pan-domain-auth-play_2-7/src/main/scala/com/gu/pandomainauth/service/oAuthModel.scala
@@ -30,8 +30,8 @@ object Token {
   }
 }
 
-case class JwtClaims(iss: String, sub: String, azp: Option[String], email: String, at_hash: String, email_verified: Boolean,
-                     aud: String, hd: Option[String], iat: Long, exp: Long)
+case class JwtClaims(iss: String, sub: String, azp: Option[String], email: Option[String], at_hash: String,
+                     email_verified: Option[Boolean], aud: String, hd: Option[String], iat: Long, exp: Long)
 object JwtClaims {
   implicit val claimsReads = Json.reads[JwtClaims]
 }


### PR DESCRIPTION
At the moment the oauth callback is expecting an `email` and `email_verified` field in the JWT payload from the oauth provider, however these fields arent part of the standard spec ( https://en.wikipedia.org/wiki/JSON_Web_Token#Standard_fields ). 

This changes it so that it will try and get it from the jwt token and then if its not present get it from the userInfo response.

I have tested with both google and our own oauth provider (BBC Login)