### PR TITLE
Add Play 2.8 artifact

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ import xerial.sbt.Sonatype.SonatypeKeys
 import xerial.sbt.Sonatype._
 import com.typesafe.sbt.pgp.PgpKeys
 
-val scala212 = "2.12.8"
+val scala212 = "2.12.11"
 
 val commonSettings =
   Seq(
@@ -101,10 +101,17 @@ lazy val panDomainAuthPlay_2_7 = project("pan-domain-auth-play_2-7")
     publishArtifact := true
   ).dependsOn(panDomainAuthCore)
 
+lazy val panDomainAuthPlay_2_8 = project("pan-domain-auth-play_2-8")
+  .settings(sonatypeReleaseSettings: _*)
+  .settings(
+    libraryDependencies ++= playLibs_2_8,
+    publishArtifact := true
+  ).dependsOn(panDomainAuthCore)
+
 lazy val exampleApp = project("pan-domain-auth-example")
   .enablePlugins(PlayScala)
   .settings(libraryDependencies ++= (awsDependencies :+ ws))
-  .dependsOn(panDomainAuthPlay_2_7)
+  .dependsOn(panDomainAuthPlay_2_8)
   .settings(sonatypeReleaseSettings: _*)
   .settings(
     publishArtifact := false
@@ -115,6 +122,7 @@ lazy val root = Project("pan-domain-auth-root", file(".")).aggregate(
   panDomainAuthCore,
   panDomainAuthPlay_2_6,
   panDomainAuthPlay_2_7,
+  panDomainAuthPlay_2_8,
   exampleApp
 ).settings(sonatypeReleaseSettings: _*).settings(
   organization := "com.gu",

--- a/pan-domain-auth-example/app/controllers/ExampleAuthActions.scala
+++ b/pan-domain-auth-example/app/controllers/ExampleAuthActions.scala
@@ -3,14 +3,16 @@ package controllers
 import com.gu.pandomainauth.PanDomain
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
-import play.api.{Configuration, Logger}
+import org.slf4j.LoggerFactory
+import play.api.{Configuration}
 
 trait ExampleAuthActions extends AuthActions {
+  private val logger = LoggerFactory.getLogger(this.getClass)
 
   def config: Configuration
 
   override def validateUser(authedUser: AuthenticatedUser): Boolean = {
-    Logger.info(s"validating user $authedUser")
+    logger.info(s"validating user $authedUser")
     PanDomain.guardianValidation(authedUser)
   }
 

--- a/pan-domain-auth-play_2-8/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-8/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -1,0 +1,327 @@
+package com.gu.pandomainauth.action
+
+import com.gu.pandomainauth.model._
+import com.gu.pandomainauth.service._
+import com.gu.pandomainauth.{PanDomain, PanDomainAuthSettingsRefresher}
+import org.slf4j.LoggerFactory
+import play.api.libs.ws.WSClient
+import play.api.mvc.Results._
+import play.api.mvc._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class UserRequest[A](val user: User, request: Request[A]) extends WrappedRequest[A](request)
+
+trait AuthActions {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  /**
+    * Play application components that you must provide in order to use AuthActions
+    */
+  def wsClient: WSClient
+  def controllerComponents: ControllerComponents
+  def panDomainSettings: PanDomainAuthSettingsRefresher
+
+  private def system: String = panDomainSettings.system
+  private def domain: String = panDomainSettings.domain
+  private def settings: PanDomainAuthSettings = panDomainSettings.settings
+
+  private implicit val ec: ExecutionContext = controllerComponents.executionContext
+
+  /**
+    * Returns true if the authed user is valid in the implementing system (meets your multifactor requirements, you recognise the email etc.).
+    *
+    * If your implementing application needs to audit logins / register new users etc then this ia also the place to do it (although in this case
+    * you should strongly consider setting cacheValidation to true).
+    *
+    * @param authedUser
+    * @return true if the user is valid in your app
+    */
+  def validateUser(authedUser: AuthenticatedUser): Boolean
+
+  /**
+    * By default the validity of the user is checked every request. If your validateUser implementation is expensive or has side effects you
+    * can override this to true and validity will only be checked the first time the user visits your app after their login is established.
+    *
+    * Note the the cache is invalidated after the user's session is re-established with the OAuth provider.
+    *
+    * @return true if you want to only check the validity of the user once for the lifetime of the user's auth session
+    */
+  def cacheValidation: Boolean = false
+
+  /**
+    * Adding an expiry extension to `APIAuthAction`s allows for a delay between an applications authentication and their
+    * respective API XHR calls expiring.
+    *
+    * By default this is 0 and thus disabled.
+    *
+    * This is particularly useful for SPAs where users have third party cookies disabled.
+    *
+    * @return the amount of delay between App and API expiry in milliseconds
+    */
+  def apiGracePeriod: Long = 0 // ms
+
+  /**
+    * The auth callback url. This is where the OAuth provider will send the user after authentication.
+    * This action on should invoke processOAuthCallback
+    *
+    * @return
+    */
+  def authCallbackUrl: String
+
+  val OAuth = new OAuth(settings.oAuthSettings, system, authCallbackUrl)
+
+  /**
+    * Application name used for initialising Google API clients for directory group checking
+    */
+  val applicationName: String = s"pan-domain-authentication-$system"
+
+  val multifactorChecker: Option[Google2FAGroupChecker] = settings.google2FAGroupSettings.map {
+    new Google2FAGroupChecker(_, panDomainSettings.bucketName, panDomainSettings.s3Client, applicationName)
+  }
+
+  /**
+    * A Play session key that stores the target URL that was being accessed when redirected for authentication
+    */
+  val LOGIN_ORIGIN_KEY = "loginOriginUrl"
+  val ANTI_FORGERY_KEY = "antiForgeryToken"
+
+  /**
+    * starts the authentication process for a user. By default this just sends the user off to the OAuth provider for auth
+    * but if you want to show welcome page with a button on it then override.
+    */
+  def sendForAuth[A](implicit request: RequestHeader, email: Option[String] = None) = {
+    val antiForgeryToken = OAuth.generateAntiForgeryToken()
+    OAuth.redirectToOAuthProvider(antiForgeryToken, email)(ec, request, wsClient) map { res =>
+      val originUrl = request.uri
+      res.withSession { request.session + (ANTI_FORGERY_KEY -> antiForgeryToken) + (LOGIN_ORIGIN_KEY -> originUrl) }
+    }
+  }
+
+  def checkMultifactor(authedUser: AuthenticatedUser) = multifactorChecker.exists(_.checkMultifactor(authedUser))
+
+  /**
+    * invoked when the user is not logged in a can't be authed - this may be when the user is not valid in yur system
+    * or when they have exoplicitly logged out.
+    *
+    * Override this to add a logged out screen and display maeesages for your app. The default implementation is
+    * to ust return a 403 response
+    *
+    * @param message
+    * @param request
+    * @return
+    */
+  def showUnauthedMessage(message: String)(implicit request: RequestHeader): Result = {
+    logger.info(message)
+    Forbidden
+  }
+
+  /**
+    * Generates the message shown to the user when user validation fails. override this to add a custom error message
+    *
+    * @param claimedAuth
+    * @return
+    */
+  def invalidUserMessage(claimedAuth: AuthenticatedUser) = s"user ${claimedAuth.user.email} not valid for $system"
+
+  def processOAuthCallback()(implicit request: RequestHeader) = {
+    val token =
+      request.session.get(ANTI_FORGERY_KEY).getOrElse(throw new OAuthException("missing anti forgery token"))
+    val originalUrl =
+      request.session.get(LOGIN_ORIGIN_KEY).getOrElse(throw new OAuthException("missing original url"))
+
+    val existingCookie = readCookie(request) // will be populated if this was a re-auth for expired login
+
+    OAuth.validatedUserIdentity(token)(request, ec, wsClient).map { claimedAuth =>
+      val authedUserData = existingCookie match {
+        case Some(c) =>
+          val existingAuth = CookieUtils.parseCookieData(c.value, settings.publicKey)
+          logger.debug("user re-authed, merging auth data")
+
+          claimedAuth.copy(
+            authenticatingSystem = system,
+            authenticatedIn = existingAuth.authenticatedIn ++ Set(system),
+            multiFactor = checkMultifactor(claimedAuth)
+          )
+        case None =>
+          logger.debug("fresh user login")
+          claimedAuth.copy(multiFactor = checkMultifactor(claimedAuth))
+      }
+
+      if (validateUser(authedUserData)) {
+        val updatedCookie = generateCookie(authedUserData)
+        Redirect(originalUrl)
+          .withCookies(updatedCookie)
+          .withSession(session = request.session - ANTI_FORGERY_KEY - LOGIN_ORIGIN_KEY)
+      } else {
+        showUnauthedMessage(invalidUserMessage(claimedAuth))
+      }
+    }
+  }
+
+  def processLogout(implicit request: RequestHeader) = {
+    flushCookie(showUnauthedMessage("logged out"))
+  }
+
+  def readAuthenticatedUser(request: RequestHeader): Option[AuthenticatedUser] = readCookie(request) map { cookie =>
+    CookieUtils.parseCookieData(cookie.value, settings.publicKey)
+  }
+
+  def readCookie(request: RequestHeader): Option[Cookie] = request.cookies.get(settings.cookieSettings.cookieName)
+
+  def generateCookie(authedUser: AuthenticatedUser): Cookie =
+    Cookie(
+      name = settings.cookieSettings.cookieName,
+      value = CookieUtils.generateCookieData(authedUser, settings.privateKey),
+      domain = Some(domain),
+      secure = true,
+      httpOnly = true
+    )
+
+  def includeSystemInCookie(authedUser: AuthenticatedUser)(result: Result): Result = {
+    val updatedAuth    = authedUser.copy(authenticatedIn = authedUser.authenticatedIn + system)
+    val updatedCookie = generateCookie(updatedAuth)
+    result.withCookies(updatedCookie)
+  }
+
+  def flushCookie(result: Result): Result = {
+    val clearCookie = DiscardingCookie(
+      name = settings.cookieSettings.cookieName,
+      domain = Some(domain),
+      secure = true
+    )
+    result.discardingCookies(clearCookie)
+  }
+
+  /**
+    * Extract the authentication status from the request.
+    */
+  def extractAuth(request: RequestHeader): AuthenticationStatus = {
+    readCookie(request).map { cookie =>
+      PanDomain.authStatus(cookie.value, settings.publicKey, validateUser, apiGracePeriod, system, cacheValidation)
+    } getOrElse NotAuthenticated
+  }
+
+  /**
+    * Action that ensures the user is logged in and validated.
+    *
+    * This action is for page load type requests where it is possible to send the user for auth
+    * and for them to interact with the auth provider. For API / XHR type requests use the APIAuthAction
+    *
+    * if the user is not authed or the auth has expired they are sent for authentication
+    */
+  object AuthAction extends ActionBuilder[UserRequest, AnyContent] {
+
+    override def parser: BodyParser[AnyContent]               = AuthActions.this.controllerComponents.parsers.default
+    override protected def executionContext: ExecutionContext = AuthActions.this.controllerComponents.executionContext
+
+    override def invokeBlock[A](request: Request[A], block: (UserRequest[A]) => Future[Result]): Future[Result] = {
+      extractAuth(request) match {
+        case NotAuthenticated =>
+          logger.debug(s"user not authed against $domain, authing")
+          sendForAuth(request)
+
+        case InvalidCookie(e) =>
+          logger.warn("error checking user's auth, clear cookie and re-auth", e)
+          // remove the invalid cookie data
+          sendForAuth(request).map(flushCookie)
+
+        case Expired(authedUser) =>
+          logger.debug(s"user ${authedUser.user.email} login expired, sending to re-auth")
+          sendForAuth(request, Some(authedUser.user.email))
+
+        case GracePeriod(authedUser) =>
+          logger.debug(s"user ${authedUser.user.email} login expired, in grace period, sending to re-auth")
+          sendForAuth(request, Some(authedUser.user.email))
+
+        case NotAuthorized(authedUser) =>
+          logger.debug(s"user not authorized, show error")
+          Future(showUnauthedMessage(invalidUserMessage(authedUser))(request))
+
+        case Authenticated(authedUser) =>
+          val response = block(new UserRequest(authedUser.user, request))
+          if (authedUser.authenticatedIn(system)) {
+            response
+          } else {
+            logger.debug(s"user ${authedUser.user.email} from other system valid: adding validity in $system.")
+            response.map(includeSystemInCookie(authedUser))
+          }
+      }
+    }
+  }
+
+  /**
+    * Action that ensures the user is logged in and validated.
+    *
+    * This action is for API / XHR type requests where the user can't be sent to the auth provider for auth. In the
+    * cases where the auth is not valid response codes are sent to the requesting app and the javascript that initiated
+    * the request should handle these appropriately
+    *
+    * If the user is not authed then a 401 response is sent, if the auth has expired then a 419 response is sent, if
+    * the user is authed but not allowed to perform the action a 403 is sent
+    *
+    * If the user is authed or has an expiry extension, a 200 is sent
+    *
+    */
+  object APIAuthAction extends AbstractApiAuthAction with PlainErrorResponses
+
+  trait PlainErrorResponses {
+    val notAuthenticatedResult = Unauthorized
+    val invalidCookieResult    = Unauthorized
+    val expiredResult          = new Status(419)
+    val notAuthorizedResult    = Forbidden
+  }
+
+  /**
+    * Abstraction for API auth actions allowing to mix in custom results for each of the different error scenarios.
+    */
+  trait AbstractApiAuthAction extends ActionBuilder[UserRequest, AnyContent] {
+
+    override def parser: BodyParser[AnyContent]               = AuthActions.this.controllerComponents.parsers.default
+    override protected def executionContext: ExecutionContext = AuthActions.this.controllerComponents.executionContext
+
+    val notAuthenticatedResult: Result
+    val invalidCookieResult: Result
+    val expiredResult: Result
+    val notAuthorizedResult: Result
+
+    override def invokeBlock[A](request: Request[A], block: (UserRequest[A]) => Future[Result]): Future[Result] = {
+      extractAuth(request) match {
+        case NotAuthenticated =>
+          logger.debug(s"user not authed against $domain, return 401")
+          Future(notAuthenticatedResult)
+
+        case InvalidCookie(e) =>
+          logger.warn("error checking user's auth, clear cookie and return 401", e)
+          // remove the invalid cookie data
+          Future(invalidCookieResult).map(flushCookie)
+
+        case Expired(authedUser) =>
+          logger.debug(s"user ${authedUser.user.email} login expired, return 419")
+          Future(expiredResult)
+
+        case GracePeriod(authedUser) =>
+          logger.debug(s"user ${authedUser.user.email} login expired but is in grace period.")
+          val response = block(new UserRequest(authedUser.user, request))
+          responseWithSystemCookie(response, authedUser)
+
+        case NotAuthorized(authedUser) =>
+          logger.debug(s"user not authorized, return 403")
+          logger.debug(invalidUserMessage(authedUser))
+          Future(notAuthorizedResult)
+
+        case Authenticated(authedUser) =>
+          val response = block(new UserRequest(authedUser.user, request))
+          responseWithSystemCookie(response, authedUser)
+      }
+    }
+
+    def responseWithSystemCookie(response: Future[Result], authedUser: AuthenticatedUser): Future[Result] =
+      if (authedUser.authenticatedIn(system)) {
+        response
+      } else {
+        logger.debug(s"user ${authedUser.user.email} from other system valid: adding validity in $system.")
+        response.map(includeSystemInCookie(authedUser))
+      }
+  }
+}

--- a/pan-domain-auth-play_2-8/src/main/scala/com/gu/pandomainauth/service/OAuth.scala
+++ b/pan-domain-auth-play_2-8/src/main/scala/com/gu/pandomainauth/service/OAuth.scala
@@ -1,0 +1,103 @@
+package com.gu.pandomainauth.service
+
+import java.math.BigInteger
+import java.security.SecureRandom
+
+import com.gu.pandomainauth.model.{AuthenticatedUser, OAuthSettings, User}
+import play.api.libs.json.JsValue
+import play.api.libs.ws.{WSClient, WSResponse}
+import play.api.mvc.Results.Redirect
+import play.api.mvc.{RequestHeader, Result}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.language.postfixOps
+
+
+class OAuthException(val message: String, val throwable: Throwable = null) extends Exception(message, throwable)
+
+class OAuth(config: OAuthSettings, system: String, redirectUrl: String) {
+  var discoveryDocumentHolder: Option[Future[DiscoveryDocument]] = None
+
+  private def discoveryDocument(implicit context: ExecutionContext, ws: WSClient): Future[DiscoveryDocument] =
+    if (discoveryDocumentHolder.isDefined) discoveryDocumentHolder.get
+    else {
+      val discoveryDocumentFuture = ws.url(config.discoveryDocumentUrl).get().map(r => DiscoveryDocument.fromJson(r.json))
+      discoveryDocumentHolder = Some(discoveryDocumentFuture)
+      discoveryDocumentFuture
+    }
+
+  val random = new SecureRandom()
+
+  def generateAntiForgeryToken() = new BigInteger(130, random).toString(32)
+
+  def oAuthResponse[T](r: WSResponse)(block: JsValue => T): T = {
+    r.status match {
+      case errorCode if errorCode >= 400 =>
+        // try to get error if we received an error doc (Google does this)
+        val error = (r.json \ "error").asOpt[Error]
+        error.map { e =>
+          throw new OAuthException(s"Error when calling OAuth provider: ${e.message}")
+        }.getOrElse {
+          throw new OAuthException(s"Unknown error when calling OAuth provider [status=$errorCode, body=${r.body}]")
+        }
+      case normal => block(r.json)
+    }
+  }
+
+  def redirectToOAuthProvider(antiForgeryToken: String, email: Option[String] = None)
+                      (implicit context: ExecutionContext, request: RequestHeader, ws: WSClient): Future[Result] = {
+    val queryString: Map[String, Seq[String]] = Map(
+      "client_id" -> Seq(config.clientId),
+      "response_type" -> Seq("code"),
+      "scope" -> Seq("openid email profile"),
+      "redirect_uri" -> Seq(redirectUrl),
+      "state" -> Seq(antiForgeryToken)
+    ) ++ email.map("login_hint" -> Seq(_))
+
+    discoveryDocument.map(dd => Redirect(s"${dd.authorization_endpoint}", queryString))
+  }
+
+  def validatedUserIdentity(expectedAntiForgeryToken: String)
+                           (implicit request: RequestHeader, context: ExecutionContext, ws: WSClient): Future[AuthenticatedUser] = {
+    if (!request.queryString.getOrElse("state", Nil).contains(expectedAntiForgeryToken)) {
+      throw new IllegalArgumentException("The anti forgery token did not match")
+    } else {
+      discoveryDocument.flatMap { dd =>
+        val code = request.queryString("code")
+        ws.url(dd.token_endpoint).post {
+          Map(
+            "code" -> code,
+            "client_id" -> Seq(config.clientId),
+            "client_secret" -> Seq(config.clientSecret),
+            "redirect_uri" -> Seq(redirectUrl),
+            "grant_type" -> Seq("authorization_code")
+          )
+        }.flatMap { response =>
+          oAuthResponse(response) { json =>
+            val token = Token.fromJson(json)
+            val jwt = token.jwt
+            ws.url(dd.userinfo_endpoint)
+              .withHttpHeaders("Authorization" -> s"Bearer ${token.access_token}")
+              .get().map { response =>
+              oAuthResponse(response) { json =>
+                val userInfo = UserInfo.fromJson(json)
+                AuthenticatedUser(
+                  user = User(
+                    userInfo.given_name,
+                    userInfo.family_name,
+                    jwt.claims.email.getOrElse(userInfo.email),
+                    userInfo.picture
+                  ),
+                  authenticatingSystem = system,
+                  authenticatedIn = Set(system),
+                  jwt.claims.exp * 1000,
+                  false
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/pan-domain-auth-play_2-8/src/main/scala/com/gu/pandomainauth/service/oAuthModel.scala
+++ b/pan-domain-auth-play_2-8/src/main/scala/com/gu/pandomainauth/service/oAuthModel.scala
@@ -1,0 +1,62 @@
+package com.gu.pandomainauth.service
+
+import play.api.libs.json._
+import play.api.libs.json.Reads._
+import play.api.libs.functional.syntax._
+import org.apache.commons.codec.binary.Base64
+
+case class DiscoveryDocument(authorization_endpoint: String, token_endpoint: String, userinfo_endpoint: String)
+object DiscoveryDocument {
+  implicit val discoveryDocumentReads = Json.reads[DiscoveryDocument]
+  def fromJson(json: JsValue) = Json.fromJson[DiscoveryDocument](json).getOrElse(
+    throw new IllegalArgumentException("Invalid discovery document")
+  )
+}
+
+case class Token(access_token:String, token_type:String, expires_in:Long, id_token:String) {
+  val jwt = JsonWebToken(id_token)
+}
+object Token {
+
+  implicit val tokenReads: Reads[Token] = (
+    (JsPath \ "access_token").read[String] and
+    (JsPath \ "token_type").read[String] and
+    (JsPath \ "expires_in").read[Long].orElse((JsPath \ "expires_in").read[String].map(_.toLong)) and
+    (JsPath \ "id_token").read[String]
+  )(Token.apply _)
+
+  def fromJson(json:JsValue):Token = {
+    Json.fromJson[Token](json).get
+  }
+}
+
+case class JwtClaims(iss: String, sub: String, azp: Option[String], email: Option[String], at_hash: String,
+                     email_verified: Option[Boolean], aud: String, hd: Option[String], iat: Long, exp: Long)
+object JwtClaims {
+  implicit val claimsReads = Json.reads[JwtClaims]
+}
+
+case class UserInfo(sub: Option[String], name: String, given_name: String, family_name: String, profile: Option[String],
+                    picture: Option[String], email: String, locale: Option[String], hd: Option[String])
+object UserInfo {
+  implicit val userInfoReads = Json.reads[UserInfo]
+
+  def fromJson(json:JsValue):UserInfo = {
+    json.as[UserInfo]
+  }
+}
+
+case class JsonWebToken(jwt: String) {
+  val jwtParts: Array[String] = jwt.split('.')
+  val Array(headerJson, claimsJson) = jwtParts.take(2).map(Base64.decodeBase64).map(Json.parse)
+  val claims = claimsJson.as[JwtClaims]
+}
+
+case class ErrorInfo(domain: String, reason: String, message: String)
+object ErrorInfo {
+  implicit val errorInfoReads = Json.reads[ErrorInfo]
+}
+case class Error(errors: Seq[ErrorInfo], code: Int, message: String)
+object Error {
+  implicit val errorReads = Json.reads[Error]
+}

--- a/pan-domain-node/package-lock.json
+++ b/pan-domain-node/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "7.0.0"
       }
     },
     "@babel/core": {
@@ -19,20 +19,20 @@
       "integrity": "sha512-Dzl7U0/T69DFOTwqz/FJdnOSWS57NpjNfCwMKHABr589Lg8uX1RrlBIJ7L5Dubt/xkLsx0xH5EBFzlBVes1ayA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.0",
-        "@babel/helpers": "^7.4.0",
-        "@babel/parser": "^7.4.0",
-        "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.0",
-        "@babel/types": "^7.4.0",
-        "convert-source-map": "^1.1.0",
-        "debug": "^4.1.0",
-        "json5": "^2.1.0",
-        "lodash": "^4.17.11",
-        "resolve": "^1.3.2",
-        "semver": "^5.4.1",
-        "source-map": "^0.5.0"
+        "@babel/code-frame": "7.0.0",
+        "@babel/generator": "7.4.0",
+        "@babel/helpers": "7.4.2",
+        "@babel/parser": "7.4.2",
+        "@babel/template": "7.4.0",
+        "@babel/traverse": "7.4.0",
+        "@babel/types": "7.4.0",
+        "convert-source-map": "1.6.0",
+        "debug": "4.1.1",
+        "json5": "2.1.0",
+        "lodash": "4.17.11",
+        "resolve": "1.10.0",
+        "semver": "5.6.0",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "debug": {
@@ -41,7 +41,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "ms": {
@@ -64,11 +64,11 @@
       "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.0",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.11",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
+        "@babel/types": "7.4.0",
+        "jsesc": "2.5.2",
+        "lodash": "4.17.11",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "source-map": {
@@ -85,9 +85,9 @@
       "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.0.0",
-        "@babel/template": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/helper-get-function-arity": "7.0.0",
+        "@babel/template": "7.4.0",
+        "@babel/types": "7.4.0"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -96,7 +96,7 @@
       "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.4.0"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -111,7 +111,7 @@
       "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.0"
+        "@babel/types": "7.4.0"
       }
     },
     "@babel/helpers": {
@@ -120,9 +120,9 @@
       "integrity": "sha512-gQR1eQeroDzFBikhrCccm5Gs2xBjZ57DNjGbqTaHo911IpmSxflOQWMAHPw/TXk8L3isv7s9lYzUkexOeTQUYg==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.4.0",
-        "@babel/traverse": "^7.4.0",
-        "@babel/types": "^7.4.0"
+        "@babel/template": "7.4.0",
+        "@babel/traverse": "7.4.0",
+        "@babel/types": "7.4.0"
       }
     },
     "@babel/highlight": {
@@ -131,9 +131,9 @@
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^4.0.0"
+        "chalk": "2.4.2",
+        "esutils": "2.0.2",
+        "js-tokens": "4.0.0"
       }
     },
     "@babel/parser": {
@@ -148,7 +148,7 @@
       "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
+        "@babel/helper-plugin-utils": "7.0.0"
       }
     },
     "@babel/template": {
@@ -157,9 +157,9 @@
       "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.4.0",
-        "@babel/types": "^7.4.0"
+        "@babel/code-frame": "7.0.0",
+        "@babel/parser": "7.4.2",
+        "@babel/types": "7.4.0"
       }
     },
     "@babel/traverse": {
@@ -168,15 +168,15 @@
       "integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.0",
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.4.0",
-        "@babel/parser": "^7.4.0",
-        "@babel/types": "^7.4.0",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.11"
+        "@babel/code-frame": "7.0.0",
+        "@babel/generator": "7.4.0",
+        "@babel/helper-function-name": "7.1.0",
+        "@babel/helper-split-export-declaration": "7.4.0",
+        "@babel/parser": "7.4.2",
+        "@babel/types": "7.4.0",
+        "debug": "4.1.1",
+        "globals": "11.11.0",
+        "lodash": "4.17.11"
       },
       "dependencies": {
         "debug": {
@@ -185,7 +185,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "ms": {
@@ -202,9 +202,9 @@
       "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.11",
-        "to-fast-properties": "^2.0.0"
+        "esutils": "2.0.2",
+        "lodash": "4.17.11",
+        "to-fast-properties": "2.0.0"
       }
     },
     "@cnakazawa/watch": {
@@ -213,8 +213,8 @@
       "integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
       "dev": true,
       "requires": {
-        "exec-sh": "^0.3.2",
-        "minimist": "^1.2.0"
+        "exec-sh": "0.3.2",
+        "minimist": "1.2.0"
       }
     },
     "@jest/console": {
@@ -223,10 +223,10 @@
       "integrity": "sha512-NaCty/OOei6rSDcbPdMiCbYCI0KGFGPgGO6B09lwWt5QTxnkuhKYET9El5u5z1GAcSxkQmSMtM63e24YabCWqA==",
       "dev": true,
       "requires": {
-        "@jest/source-map": "^24.3.0",
-        "@types/node": "*",
-        "chalk": "^2.0.1",
-        "slash": "^2.0.0"
+        "@jest/source-map": "24.3.0",
+        "@types/node": "11.11.6",
+        "chalk": "2.4.2",
+        "slash": "2.0.0"
       }
     },
     "@jest/core": {
@@ -235,33 +235,33 @@
       "integrity": "sha512-RDZArRzAs51YS7dXG1pbXbWGxK53rvUu8mCDYsgqqqQ6uSOaTjcVyBl2Jce0exT2rSLk38ca7az7t2f3b0/oYQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^24.3.0",
-        "@jest/reporters": "^24.5.0",
-        "@jest/test-result": "^24.5.0",
-        "@jest/transform": "^24.5.0",
-        "@jest/types": "^24.5.0",
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.1",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.1.15",
-        "jest-changed-files": "^24.5.0",
-        "jest-config": "^24.5.0",
-        "jest-haste-map": "^24.5.0",
-        "jest-message-util": "^24.5.0",
-        "jest-regex-util": "^24.3.0",
-        "jest-resolve-dependencies": "^24.5.0",
-        "jest-runner": "^24.5.0",
-        "jest-runtime": "^24.5.0",
-        "jest-snapshot": "^24.5.0",
-        "jest-util": "^24.5.0",
-        "jest-validate": "^24.5.0",
-        "jest-watcher": "^24.5.0",
-        "micromatch": "^3.1.10",
-        "p-each-series": "^1.0.0",
-        "pirates": "^4.0.1",
-        "realpath-native": "^1.1.0",
-        "rimraf": "^2.5.4",
-        "strip-ansi": "^5.0.0"
+        "@jest/console": "24.3.0",
+        "@jest/reporters": "24.5.0",
+        "@jest/test-result": "24.5.0",
+        "@jest/transform": "24.5.0",
+        "@jest/types": "24.5.0",
+        "ansi-escapes": "3.2.0",
+        "chalk": "2.4.2",
+        "exit": "0.1.2",
+        "graceful-fs": "4.1.15",
+        "jest-changed-files": "24.5.0",
+        "jest-config": "24.5.0",
+        "jest-haste-map": "24.5.0",
+        "jest-message-util": "24.5.0",
+        "jest-regex-util": "24.3.0",
+        "jest-resolve-dependencies": "24.5.0",
+        "jest-runner": "24.5.0",
+        "jest-runtime": "24.5.0",
+        "jest-snapshot": "24.5.0",
+        "jest-util": "24.5.0",
+        "jest-validate": "24.5.0",
+        "jest-watcher": "24.5.0",
+        "micromatch": "3.1.10",
+        "p-each-series": "1.0.0",
+        "pirates": "4.0.1",
+        "realpath-native": "1.1.0",
+        "rimraf": "2.6.3",
+        "strip-ansi": "5.2.0"
       }
     },
     "@jest/environment": {
@@ -270,11 +270,11 @@
       "integrity": "sha512-tzUHR9SHjMXwM8QmfHb/EJNbF0fjbH4ieefJBvtwO8YErLTrecc1ROj0uo2VnIT6SlpEGZnvdCK6VgKYBo8LsA==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^24.5.0",
-        "@jest/transform": "^24.5.0",
-        "@jest/types": "^24.5.0",
-        "@types/node": "*",
-        "jest-mock": "^24.5.0"
+        "@jest/fake-timers": "24.5.0",
+        "@jest/transform": "24.5.0",
+        "@jest/types": "24.5.0",
+        "@types/node": "11.11.6",
+        "jest-mock": "24.5.0"
       }
     },
     "@jest/fake-timers": {
@@ -283,10 +283,10 @@
       "integrity": "sha512-i59KVt3QBz9d+4Qr4QxsKgsIg+NjfuCjSOWj3RQhjF5JNy+eVJDhANQ4WzulzNCHd72srMAykwtRn5NYDGVraw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.5.0",
-        "@types/node": "*",
-        "jest-message-util": "^24.5.0",
-        "jest-mock": "^24.5.0"
+        "@jest/types": "24.5.0",
+        "@types/node": "11.11.6",
+        "jest-message-util": "24.5.0",
+        "jest-mock": "24.5.0"
       }
     },
     "@jest/reporters": {
@@ -295,26 +295,26 @@
       "integrity": "sha512-vfpceiaKtGgnuC3ss5czWOihKOUSyjJA4M4udm6nH8xgqsuQYcyDCi4nMMcBKsHXWgz9/V5G7iisnZGfOh1w6Q==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^24.5.0",
-        "@jest/test-result": "^24.5.0",
-        "@jest/transform": "^24.5.0",
-        "@jest/types": "^24.5.0",
-        "chalk": "^2.0.1",
-        "exit": "^0.1.2",
-        "glob": "^7.1.2",
-        "istanbul-api": "^2.1.1",
-        "istanbul-lib-coverage": "^2.0.2",
-        "istanbul-lib-instrument": "^3.0.1",
-        "istanbul-lib-source-maps": "^3.0.1",
-        "jest-haste-map": "^24.5.0",
-        "jest-resolve": "^24.5.0",
-        "jest-runtime": "^24.5.0",
-        "jest-util": "^24.5.0",
-        "jest-worker": "^24.4.0",
-        "node-notifier": "^5.2.1",
-        "slash": "^2.0.0",
-        "source-map": "^0.6.0",
-        "string-length": "^2.0.0"
+        "@jest/environment": "24.5.0",
+        "@jest/test-result": "24.5.0",
+        "@jest/transform": "24.5.0",
+        "@jest/types": "24.5.0",
+        "chalk": "2.4.2",
+        "exit": "0.1.2",
+        "glob": "7.1.3",
+        "istanbul-api": "2.1.1",
+        "istanbul-lib-coverage": "2.0.3",
+        "istanbul-lib-instrument": "3.1.0",
+        "istanbul-lib-source-maps": "3.0.2",
+        "jest-haste-map": "24.5.0",
+        "jest-resolve": "24.5.0",
+        "jest-runtime": "24.5.0",
+        "jest-util": "24.5.0",
+        "jest-worker": "24.4.0",
+        "node-notifier": "5.4.0",
+        "slash": "2.0.0",
+        "source-map": "0.6.1",
+        "string-length": "2.0.0"
       }
     },
     "@jest/source-map": {
@@ -323,9 +323,9 @@
       "integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
       "dev": true,
       "requires": {
-        "callsites": "^3.0.0",
-        "graceful-fs": "^4.1.15",
-        "source-map": "^0.6.0"
+        "callsites": "3.0.0",
+        "graceful-fs": "4.1.15",
+        "source-map": "0.6.1"
       }
     },
     "@jest/test-result": {
@@ -334,9 +334,9 @@
       "integrity": "sha512-u66j2vBfa8Bli1+o3rCaVnVYa9O8CAFZeqiqLVhnarXtreSXG33YQ6vNYBogT7+nYiFNOohTU21BKiHlgmxD5A==",
       "dev": true,
       "requires": {
-        "@jest/console": "^24.3.0",
-        "@jest/types": "^24.5.0",
-        "@types/istanbul-lib-coverage": "^1.1.0"
+        "@jest/console": "24.3.0",
+        "@jest/types": "24.5.0",
+        "@types/istanbul-lib-coverage": "1.1.0"
       }
     },
     "@jest/transform": {
@@ -345,20 +345,20 @@
       "integrity": "sha512-XSsDz1gdR/QMmB8UCKlweAReQsZrD/DK7FuDlNo/pE8EcKMrfi2kqLRk8h8Gy/PDzgqJj64jNEzOce9pR8oj1w==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.1.0",
-        "@jest/types": "^24.5.0",
-        "babel-plugin-istanbul": "^5.1.0",
-        "chalk": "^2.0.1",
-        "convert-source-map": "^1.4.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "graceful-fs": "^4.1.15",
-        "jest-haste-map": "^24.5.0",
-        "jest-regex-util": "^24.3.0",
-        "jest-util": "^24.5.0",
-        "micromatch": "^3.1.10",
-        "realpath-native": "^1.1.0",
-        "slash": "^2.0.0",
-        "source-map": "^0.6.1",
+        "@babel/core": "7.4.0",
+        "@jest/types": "24.5.0",
+        "babel-plugin-istanbul": "5.1.1",
+        "chalk": "2.4.2",
+        "convert-source-map": "1.6.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "graceful-fs": "4.1.15",
+        "jest-haste-map": "24.5.0",
+        "jest-regex-util": "24.3.0",
+        "jest-util": "24.5.0",
+        "micromatch": "3.1.10",
+        "realpath-native": "1.1.0",
+        "slash": "2.0.0",
+        "source-map": "0.6.1",
         "write-file-atomic": "2.4.1"
       }
     },
@@ -368,8 +368,8 @@
       "integrity": "sha512-kN7RFzNMf2R8UDadPOl6ReyI+MT8xfqRuAnuVL+i4gwjv/zubdDK+EDeLHYwq1j0CSSR2W/MmgaRlMZJzXdmVA==",
       "dev": true,
       "requires": {
-        "@types/istanbul-lib-coverage": "^1.1.0",
-        "@types/yargs": "^12.0.9"
+        "@types/istanbul-lib-coverage": "1.1.0",
+        "@types/yargs": "12.0.10"
       }
     },
     "@types/babel__core": {
@@ -378,11 +378,11 @@
       "integrity": "sha512-wJTeJRt7BToFx3USrCDs2BhEi4ijBInTQjOIukj6a/5tEkwpFMVZ+1ppgmE+Q/FQyc5P/VWUbx7I9NELrKruHA==",
       "dev": true,
       "requires": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
+        "@babel/parser": "7.4.2",
+        "@babel/types": "7.4.0",
+        "@types/babel__generator": "7.0.2",
+        "@types/babel__template": "7.0.2",
+        "@types/babel__traverse": "7.0.6"
       }
     },
     "@types/babel__generator": {
@@ -391,7 +391,7 @@
       "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "7.4.0"
       }
     },
     "@types/babel__template": {
@@ -400,8 +400,8 @@
       "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
       "dev": true,
       "requires": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
+        "@babel/parser": "7.4.2",
+        "@babel/types": "7.4.0"
       }
     },
     "@types/babel__traverse": {
@@ -410,7 +410,7 @@
       "integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.3.0"
+        "@babel/types": "7.4.0"
       }
     },
     "@types/cookie": {
@@ -437,7 +437,7 @@
       "integrity": "sha512-2kLuPC5FDnWIDvaJBzsGTBQaBbnDweznicvK7UGYzlIJP4RJR2a4A/ByLUXEyEgag6jz8eHdlWExGDtH3EYUXQ==",
       "dev": true,
       "requires": {
-        "@types/jest-diff": "*"
+        "@types/jest-diff": "20.0.1"
       }
     },
     "@types/jest-diff": {
@@ -482,8 +482,8 @@
       "integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
       "dev": true,
       "requires": {
-        "acorn": "^6.0.1",
-        "acorn-walk": "^6.0.1"
+        "acorn": "6.1.1",
+        "acorn-walk": "6.1.1"
       },
       "dependencies": {
         "acorn": {
@@ -506,10 +506,10 @@
       "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "2.0.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.2.2"
       }
     },
     "ansi-escapes": {
@@ -530,7 +530,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.3"
       }
     },
     "anymatch": {
@@ -539,8 +539,8 @@
       "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "dev": true,
       "requires": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
+        "micromatch": "3.1.10",
+        "normalize-path": "2.1.1"
       }
     },
     "append-transform": {
@@ -549,7 +549,7 @@
       "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
       "dev": true,
       "requires": {
-        "default-require-extensions": "^2.0.0"
+        "default-require-extensions": "2.0.0"
       }
     },
     "argparse": {
@@ -558,7 +558,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -603,7 +603,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "~2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "assert-plus": {
@@ -630,7 +630,7 @@
       "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.11"
+        "lodash": "4.17.11"
       }
     },
     "async-limiter": {
@@ -669,13 +669,13 @@
       "integrity": "sha512-0fKCXyRwxFTJL0UXDJiT2xYxO9Lu2vBd9n+cC+eDjESzcVG3s2DRGAxbzJX21fceB1WYoBjAh8pQ83dKcl003g==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^24.5.0",
-        "@jest/types": "^24.5.0",
-        "@types/babel__core": "^7.1.0",
-        "babel-plugin-istanbul": "^5.1.0",
-        "babel-preset-jest": "^24.3.0",
-        "chalk": "^2.4.2",
-        "slash": "^2.0.0"
+        "@jest/transform": "24.5.0",
+        "@jest/types": "24.5.0",
+        "@types/babel__core": "7.1.0",
+        "babel-plugin-istanbul": "5.1.1",
+        "babel-preset-jest": "24.3.0",
+        "chalk": "2.4.2",
+        "slash": "2.0.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -684,9 +684,9 @@
       "integrity": "sha512-RNNVv2lsHAXJQsEJ5jonQwrJVWK8AcZpG1oxhnjCUaAjL7xahYLANhPUZbzEQHjKy1NMYUwn+0NPKQc8iSY4xQ==",
       "dev": true,
       "requires": {
-        "find-up": "^3.0.0",
-        "istanbul-lib-instrument": "^3.0.0",
-        "test-exclude": "^5.0.0"
+        "find-up": "3.0.0",
+        "istanbul-lib-instrument": "3.1.0",
+        "test-exclude": "5.1.0"
       }
     },
     "babel-plugin-jest-hoist": {
@@ -695,7 +695,7 @@
       "integrity": "sha512-nWh4N1mVH55Tzhx2isvUN5ebM5CDUvIpXPZYMRazQughie/EqGnbR+czzoQlhUmJG9pPJmYDRhvocotb2THl1w==",
       "dev": true,
       "requires": {
-        "@types/babel__traverse": "^7.0.6"
+        "@types/babel__traverse": "7.0.6"
       }
     },
     "babel-preset-jest": {
@@ -704,8 +704,8 @@
       "integrity": "sha512-VGTV2QYBa/Kn3WCOKdfS31j9qomaXSgJqi65B6o05/1GsJyj9LVhSljM9ro4S+IBGj/ENhNBuH9bpqzztKAQSw==",
       "dev": true,
       "requires": {
-        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-        "babel-plugin-jest-hoist": "^24.3.0"
+        "@babel/plugin-syntax-object-rest-spread": "7.2.0",
+        "babel-plugin-jest-hoist": "24.3.0"
       }
     },
     "balanced-match": {
@@ -720,13 +720,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -735,7 +735,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -744,7 +744,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -753,7 +753,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -762,9 +762,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -775,7 +775,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "brace-expansion": {
@@ -784,7 +784,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -794,16 +794,16 @@
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
+        "arr-flatten": "1.1.0",
+        "array-unique": "0.3.2",
+        "extend-shallow": "2.0.1",
+        "fill-range": "4.0.0",
+        "isobject": "3.0.1",
+        "repeat-element": "1.1.3",
+        "snapdragon": "0.8.2",
+        "snapdragon-node": "2.1.1",
+        "split-string": "3.1.0",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "extend-shallow": {
@@ -812,7 +812,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -846,7 +846,7 @@
       "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
       "dev": true,
       "requires": {
-        "fast-json-stable-stringify": "2.x"
+        "fast-json-stable-stringify": "2.0.0"
       }
     },
     "bser": {
@@ -855,7 +855,7 @@
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "dev": true,
       "requires": {
-        "node-int64": "^0.4.0"
+        "node-int64": "0.4.0"
       }
     },
     "buffer-from": {
@@ -870,15 +870,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
       }
     },
     "callsites": {
@@ -899,7 +899,7 @@
       "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
       "dev": true,
       "requires": {
-        "rsvp": "^4.8.4"
+        "rsvp": "4.8.4"
       }
     },
     "caseless": {
@@ -914,9 +914,9 @@
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.5.0"
       }
     },
     "ci-info": {
@@ -931,10 +931,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -943,7 +943,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -954,9 +954,9 @@
       "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "2.1.1",
+        "strip-ansi": "4.0.0",
+        "wrap-ansi": "2.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -971,7 +971,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -994,8 +994,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
@@ -1019,7 +1019,7 @@
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -1053,7 +1053,7 @@
       "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "cookie": {
@@ -1079,11 +1079,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "nice-try": "1.0.5",
+        "path-key": "2.0.1",
+        "semver": "5.6.0",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "cssom": {
@@ -1098,7 +1098,7 @@
       "integrity": "sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==",
       "dev": true,
       "requires": {
-        "cssom": "0.3.x"
+        "cssom": "0.3.6"
       }
     },
     "dashdash": {
@@ -1107,7 +1107,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "data-urls": {
@@ -1116,9 +1116,9 @@
       "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
       "dev": true,
       "requires": {
-        "abab": "^2.0.0",
-        "whatwg-mimetype": "^2.2.0",
-        "whatwg-url": "^7.0.0"
+        "abab": "2.0.0",
+        "whatwg-mimetype": "2.3.0",
+        "whatwg-url": "7.0.0"
       },
       "dependencies": {
         "whatwg-url": {
@@ -1127,9 +1127,9 @@
           "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
           "dev": true,
           "requires": {
-            "lodash.sortby": "^4.7.0",
-            "tr46": "^1.0.1",
-            "webidl-conversions": "^4.0.2"
+            "lodash.sortby": "4.7.0",
+            "tr46": "1.0.1",
+            "webidl-conversions": "4.0.2"
           }
         }
       }
@@ -1167,7 +1167,7 @@
       "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
       "dev": true,
       "requires": {
-        "strip-bom": "^3.0.0"
+        "strip-bom": "3.0.0"
       }
     },
     "define-properties": {
@@ -1176,7 +1176,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "object-keys": "1.1.0"
       }
     },
     "define-property": {
@@ -1185,8 +1185,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -1195,7 +1195,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -1204,7 +1204,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -1213,9 +1213,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -1244,7 +1244,7 @@
       "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
       "dev": true,
       "requires": {
-        "webidl-conversions": "^4.0.2"
+        "webidl-conversions": "4.0.2"
       }
     },
     "ecc-jsbn": {
@@ -1253,8 +1253,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "end-of-stream": {
@@ -1263,7 +1263,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "error-ex": {
@@ -1272,7 +1272,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es-abstract": {
@@ -1281,12 +1281,12 @@
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.2.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
+        "es-to-primitive": "1.2.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "is-callable": "1.1.4",
+        "is-regex": "1.0.4",
+        "object-keys": "1.1.0"
       }
     },
     "es-to-primitive": {
@@ -1295,9 +1295,9 @@
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+        "is-callable": "1.1.4",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.2"
       }
     },
     "escape-string-regexp": {
@@ -1312,11 +1312,11 @@
       "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
       "dev": true,
       "requires": {
-        "esprima": "^3.1.3",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -1357,13 +1357,13 @@
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "6.0.5",
+        "get-stream": "4.1.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "exit": {
@@ -1378,13 +1378,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -1393,7 +1393,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -1402,7 +1402,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -1413,12 +1413,12 @@
       "integrity": "sha512-p2Gmc0CLxOgkyA93ySWmHFYHUPFIHG6XZ06l7WArWAsrqYVaVEkOU5NtT5i68KUyGKbkQgDCkiT65bWmdoL6Bw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.5.0",
-        "ansi-styles": "^3.2.0",
-        "jest-get-type": "^24.3.0",
-        "jest-matcher-utils": "^24.5.0",
-        "jest-message-util": "^24.5.0",
-        "jest-regex-util": "^24.3.0"
+        "@jest/types": "24.5.0",
+        "ansi-styles": "3.2.1",
+        "jest-get-type": "24.3.0",
+        "jest-matcher-utils": "24.5.0",
+        "jest-message-util": "24.5.0",
+        "jest-regex-util": "24.3.0"
       }
     },
     "extend": {
@@ -1433,8 +1433,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -1443,7 +1443,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -1454,14 +1454,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -1470,7 +1470,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "extend-shallow": {
@@ -1479,7 +1479,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "is-accessor-descriptor": {
@@ -1488,7 +1488,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -1497,7 +1497,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -1506,9 +1506,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -1543,7 +1543,7 @@
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "dev": true,
       "requires": {
-        "bser": "^2.0.0"
+        "bser": "2.0.0"
       }
     },
     "fileset": {
@@ -1552,8 +1552,8 @@
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.3",
-        "minimatch": "^3.0.3"
+        "glob": "7.1.3",
+        "minimatch": "3.0.4"
       }
     },
     "fill-range": {
@@ -1562,10 +1562,10 @@
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
+        "extend-shallow": "2.0.1",
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1",
+        "to-regex-range": "2.1.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -1574,7 +1574,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -1585,7 +1585,7 @@
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
       "requires": {
-        "locate-path": "^3.0.0"
+        "locate-path": "3.0.0"
       }
     },
     "for-in": {
@@ -1606,9 +1606,9 @@
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.7",
+        "mime-types": "2.1.22"
       }
     },
     "fragment-cache": {
@@ -1617,7 +1617,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "fs.realpath": {
@@ -1644,7 +1644,7 @@
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
       "requires": {
-        "pump": "^3.0.0"
+        "pump": "3.0.0"
       }
     },
     "get-value": {
@@ -1659,7 +1659,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "glob": {
@@ -1668,12 +1668,12 @@
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "globals": {
@@ -1700,10 +1700,10 @@
       "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
       "dev": true,
       "requires": {
-        "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
+        "neo-async": "2.6.0",
+        "optimist": "0.6.1",
+        "source-map": "0.6.1",
+        "uglify-js": "3.5.2"
       }
     },
     "har-schema": {
@@ -1718,8 +1718,8 @@
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
+        "ajv": "6.10.0",
+        "har-schema": "2.0.0"
       }
     },
     "has": {
@@ -1728,7 +1728,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
     },
     "has-flag": {
@@ -1749,9 +1749,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "has-values": {
@@ -1760,8 +1760,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "kind-of": {
@@ -1770,7 +1770,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -1787,7 +1787,7 @@
       "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "^1.0.1"
+        "whatwg-encoding": "1.0.5"
       }
     },
     "http-signature": {
@@ -1796,9 +1796,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.16.1"
       }
     },
     "iconv-lite": {
@@ -1807,7 +1807,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "import-local": {
@@ -1816,8 +1816,8 @@
       "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
       "dev": true,
       "requires": {
-        "pkg-dir": "^3.0.0",
-        "resolve-cwd": "^2.0.0"
+        "pkg-dir": "3.0.0",
+        "resolve-cwd": "2.0.0"
       }
     },
     "imurmurhash": {
@@ -1832,8 +1832,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -1853,7 +1853,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "invert-kv": {
@@ -1868,7 +1868,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -1877,7 +1877,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -1906,7 +1906,7 @@
       "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "dev": true,
       "requires": {
-        "ci-info": "^2.0.0"
+        "ci-info": "2.0.0"
       }
     },
     "is-data-descriptor": {
@@ -1915,7 +1915,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -1924,7 +1924,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -1941,9 +1941,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -1978,7 +1978,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -1987,7 +1987,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -1998,7 +1998,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "is-regex": {
@@ -2007,7 +2007,7 @@
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.3"
       }
     },
     "is-stream": {
@@ -2022,7 +2022,7 @@
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "1.0.0"
       }
     },
     "is-typedarray": {
@@ -2073,19 +2073,19 @@
       "integrity": "sha512-kVmYrehiwyeBAk/wE71tW6emzLiHGjYIiDrc8sfyty4F8M02/lrgXSm+R1kXysmF20zArvmZXjlE/mg24TVPJw==",
       "dev": true,
       "requires": {
-        "async": "^2.6.1",
-        "compare-versions": "^3.2.1",
-        "fileset": "^2.0.3",
-        "istanbul-lib-coverage": "^2.0.3",
-        "istanbul-lib-hook": "^2.0.3",
-        "istanbul-lib-instrument": "^3.1.0",
-        "istanbul-lib-report": "^2.0.4",
-        "istanbul-lib-source-maps": "^3.0.2",
-        "istanbul-reports": "^2.1.1",
-        "js-yaml": "^3.12.0",
-        "make-dir": "^1.3.0",
-        "minimatch": "^3.0.4",
-        "once": "^1.4.0"
+        "async": "2.6.2",
+        "compare-versions": "3.4.0",
+        "fileset": "2.0.3",
+        "istanbul-lib-coverage": "2.0.3",
+        "istanbul-lib-hook": "2.0.3",
+        "istanbul-lib-instrument": "3.1.0",
+        "istanbul-lib-report": "2.0.4",
+        "istanbul-lib-source-maps": "3.0.2",
+        "istanbul-reports": "2.1.1",
+        "js-yaml": "3.13.0",
+        "make-dir": "1.3.0",
+        "minimatch": "3.0.4",
+        "once": "1.4.0"
       }
     },
     "istanbul-lib-coverage": {
@@ -2100,7 +2100,7 @@
       "integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
       "dev": true,
       "requires": {
-        "append-transform": "^1.0.0"
+        "append-transform": "1.0.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -2109,13 +2109,13 @@
       "integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
       "dev": true,
       "requires": {
-        "@babel/generator": "^7.0.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/template": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "istanbul-lib-coverage": "^2.0.3",
-        "semver": "^5.5.0"
+        "@babel/generator": "7.4.0",
+        "@babel/parser": "7.4.2",
+        "@babel/template": "7.4.0",
+        "@babel/traverse": "7.4.0",
+        "@babel/types": "7.4.0",
+        "istanbul-lib-coverage": "2.0.3",
+        "semver": "5.6.0"
       }
     },
     "istanbul-lib-report": {
@@ -2124,9 +2124,9 @@
       "integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "^2.0.3",
-        "make-dir": "^1.3.0",
-        "supports-color": "^6.0.0"
+        "istanbul-lib-coverage": "2.0.3",
+        "make-dir": "1.3.0",
+        "supports-color": "6.1.0"
       },
       "dependencies": {
         "supports-color": {
@@ -2135,7 +2135,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -2146,11 +2146,11 @@
       "integrity": "sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==",
       "dev": true,
       "requires": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^2.0.3",
-        "make-dir": "^1.3.0",
-        "rimraf": "^2.6.2",
-        "source-map": "^0.6.1"
+        "debug": "4.1.1",
+        "istanbul-lib-coverage": "2.0.3",
+        "make-dir": "1.3.0",
+        "rimraf": "2.6.3",
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "debug": {
@@ -2159,7 +2159,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "ms": {
@@ -2176,7 +2176,7 @@
       "integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.1.0"
+        "handlebars": "4.1.1"
       }
     },
     "jest": {
@@ -2185,8 +2185,8 @@
       "integrity": "sha512-lxL+Fq5/RH7inxxmfS2aZLCf8MsS+YCUBfeiNO6BWz/MmjhDGaIEA/2bzEf9q4Q0X+mtFHiinHFvQ0u+RvW/qQ==",
       "dev": true,
       "requires": {
-        "import-local": "^2.0.0",
-        "jest-cli": "^24.5.0"
+        "import-local": "2.0.0",
+        "jest-cli": "24.5.0"
       },
       "dependencies": {
         "jest-cli": {
@@ -2195,19 +2195,19 @@
           "integrity": "sha512-P+Jp0SLO4KWN0cGlNtC7JV0dW1eSFR7eRpoOucP2UM0sqlzp/bVHeo71Omonvigrj9AvCKy7NtQANtqJ7FXz8g==",
           "dev": true,
           "requires": {
-            "@jest/core": "^24.5.0",
-            "@jest/test-result": "^24.5.0",
-            "@jest/types": "^24.5.0",
-            "chalk": "^2.0.1",
-            "exit": "^0.1.2",
-            "import-local": "^2.0.0",
-            "is-ci": "^2.0.0",
-            "jest-config": "^24.5.0",
-            "jest-util": "^24.5.0",
-            "jest-validate": "^24.5.0",
-            "prompts": "^2.0.1",
-            "realpath-native": "^1.1.0",
-            "yargs": "^12.0.2"
+            "@jest/core": "24.5.0",
+            "@jest/test-result": "24.5.0",
+            "@jest/types": "24.5.0",
+            "chalk": "2.4.2",
+            "exit": "0.1.2",
+            "import-local": "2.0.0",
+            "is-ci": "2.0.0",
+            "jest-config": "24.5.0",
+            "jest-util": "24.5.0",
+            "jest-validate": "24.5.0",
+            "prompts": "2.0.4",
+            "realpath-native": "1.1.0",
+            "yargs": "12.0.5"
           }
         }
       }
@@ -2218,9 +2218,9 @@
       "integrity": "sha512-Ikl29dosYnTsH9pYa1Tv9POkILBhN/TLZ37xbzgNsZ1D2+2n+8oEZS2yP1BrHn/T4Rs4Ggwwbp/x8CKOS5YJOg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.5.0",
-        "execa": "^1.0.0",
-        "throat": "^4.0.0"
+        "@jest/types": "24.5.0",
+        "execa": "1.0.0",
+        "throat": "4.1.0"
       }
     },
     "jest-config": {
@@ -2229,22 +2229,22 @@
       "integrity": "sha512-t2UTh0Z2uZhGBNVseF8wA2DS2SuBiLOL6qpLq18+OZGfFUxTM7BzUVKyHFN/vuN+s/aslY1COW95j1Rw81huOQ==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.1.0",
-        "@jest/types": "^24.5.0",
-        "babel-jest": "^24.5.0",
-        "chalk": "^2.0.1",
-        "glob": "^7.1.1",
-        "jest-environment-jsdom": "^24.5.0",
-        "jest-environment-node": "^24.5.0",
-        "jest-get-type": "^24.3.0",
-        "jest-jasmine2": "^24.5.0",
-        "jest-regex-util": "^24.3.0",
-        "jest-resolve": "^24.5.0",
-        "jest-util": "^24.5.0",
-        "jest-validate": "^24.5.0",
-        "micromatch": "^3.1.10",
-        "pretty-format": "^24.5.0",
-        "realpath-native": "^1.1.0"
+        "@babel/core": "7.4.0",
+        "@jest/types": "24.5.0",
+        "babel-jest": "24.5.0",
+        "chalk": "2.4.2",
+        "glob": "7.1.3",
+        "jest-environment-jsdom": "24.5.0",
+        "jest-environment-node": "24.5.0",
+        "jest-get-type": "24.3.0",
+        "jest-jasmine2": "24.5.0",
+        "jest-regex-util": "24.3.0",
+        "jest-resolve": "24.5.0",
+        "jest-util": "24.5.0",
+        "jest-validate": "24.5.0",
+        "micromatch": "3.1.10",
+        "pretty-format": "24.5.0",
+        "realpath-native": "1.1.0"
       }
     },
     "jest-diff": {
@@ -2253,10 +2253,10 @@
       "integrity": "sha512-mCILZd9r7zqL9Uh6yNoXjwGQx0/J43OD2vvWVKwOEOLZliQOsojXwqboubAQ+Tszrb6DHGmNU7m4whGeB9YOqw==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "diff-sequences": "^24.3.0",
-        "jest-get-type": "^24.3.0",
-        "pretty-format": "^24.5.0"
+        "chalk": "2.4.2",
+        "diff-sequences": "24.3.0",
+        "jest-get-type": "24.3.0",
+        "pretty-format": "24.5.0"
       }
     },
     "jest-docblock": {
@@ -2265,7 +2265,7 @@
       "integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
       "dev": true,
       "requires": {
-        "detect-newline": "^2.1.0"
+        "detect-newline": "2.1.0"
       }
     },
     "jest-each": {
@@ -2274,11 +2274,11 @@
       "integrity": "sha512-6gy3Kh37PwIT5sNvNY2VchtIFOOBh8UCYnBlxXMb5sr5wpJUDPTUATX2Axq1Vfk+HWTMpsYPeVYp4TXx5uqUBw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.5.0",
-        "chalk": "^2.0.1",
-        "jest-get-type": "^24.3.0",
-        "jest-util": "^24.5.0",
-        "pretty-format": "^24.5.0"
+        "@jest/types": "24.5.0",
+        "chalk": "2.4.2",
+        "jest-get-type": "24.3.0",
+        "jest-util": "24.5.0",
+        "pretty-format": "24.5.0"
       }
     },
     "jest-environment-jsdom": {
@@ -2287,12 +2287,12 @@
       "integrity": "sha512-62Ih5HbdAWcsqBx2ktUnor/mABBo1U111AvZWcLKeWN/n/gc5ZvDBKe4Og44fQdHKiXClrNGC6G0mBo6wrPeGQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^24.5.0",
-        "@jest/fake-timers": "^24.5.0",
-        "@jest/types": "^24.5.0",
-        "jest-mock": "^24.5.0",
-        "jest-util": "^24.5.0",
-        "jsdom": "^11.5.1"
+        "@jest/environment": "24.5.0",
+        "@jest/fake-timers": "24.5.0",
+        "@jest/types": "24.5.0",
+        "jest-mock": "24.5.0",
+        "jest-util": "24.5.0",
+        "jsdom": "11.12.0"
       }
     },
     "jest-environment-node": {
@@ -2301,11 +2301,11 @@
       "integrity": "sha512-du6FuyWr/GbKLsmAbzNF9mpr2Iu2zWSaq/BNHzX+vgOcts9f2ayXBweS7RAhr+6bLp6qRpMB6utAMF5Ygktxnw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^24.5.0",
-        "@jest/fake-timers": "^24.5.0",
-        "@jest/types": "^24.5.0",
-        "jest-mock": "^24.5.0",
-        "jest-util": "^24.5.0"
+        "@jest/environment": "24.5.0",
+        "@jest/fake-timers": "24.5.0",
+        "@jest/types": "24.5.0",
+        "jest-mock": "24.5.0",
+        "jest-util": "24.5.0"
       }
     },
     "jest-get-type": {
@@ -2320,15 +2320,15 @@
       "integrity": "sha512-mb4Yrcjw9vBgSvobDwH8QUovxApdimGcOkp+V1ucGGw4Uvr3VzZQBJhNm1UY3dXYm4XXyTW2G7IBEZ9pM2ggRQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.5.0",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.1.15",
-        "invariant": "^2.2.4",
-        "jest-serializer": "^24.4.0",
-        "jest-util": "^24.5.0",
-        "jest-worker": "^24.4.0",
-        "micromatch": "^3.1.10",
-        "sane": "^4.0.3"
+        "@jest/types": "24.5.0",
+        "fb-watchman": "2.0.0",
+        "graceful-fs": "4.1.15",
+        "invariant": "2.2.4",
+        "jest-serializer": "24.4.0",
+        "jest-util": "24.5.0",
+        "jest-worker": "24.4.0",
+        "micromatch": "3.1.10",
+        "sane": "4.1.0"
       }
     },
     "jest-jasmine2": {
@@ -2337,22 +2337,22 @@
       "integrity": "sha512-sfVrxVcx1rNUbBeyIyhkqZ4q+seNKyAG6iM0S2TYBdQsXjoFDdqWFfsUxb6uXSsbimbXX/NMkJIwUZ1uT9+/Aw==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^24.5.0",
-        "@jest/test-result": "^24.5.0",
-        "@jest/types": "^24.5.0",
-        "chalk": "^2.0.1",
-        "co": "^4.6.0",
-        "expect": "^24.5.0",
-        "is-generator-fn": "^2.0.0",
-        "jest-each": "^24.5.0",
-        "jest-matcher-utils": "^24.5.0",
-        "jest-message-util": "^24.5.0",
-        "jest-runtime": "^24.5.0",
-        "jest-snapshot": "^24.5.0",
-        "jest-util": "^24.5.0",
-        "pretty-format": "^24.5.0",
-        "throat": "^4.0.0"
+        "@babel/traverse": "7.4.0",
+        "@jest/environment": "24.5.0",
+        "@jest/test-result": "24.5.0",
+        "@jest/types": "24.5.0",
+        "chalk": "2.4.2",
+        "co": "4.6.0",
+        "expect": "24.5.0",
+        "is-generator-fn": "2.0.0",
+        "jest-each": "24.5.0",
+        "jest-matcher-utils": "24.5.0",
+        "jest-message-util": "24.5.0",
+        "jest-runtime": "24.5.0",
+        "jest-snapshot": "24.5.0",
+        "jest-util": "24.5.0",
+        "pretty-format": "24.5.0",
+        "throat": "4.1.0"
       }
     },
     "jest-leak-detector": {
@@ -2361,7 +2361,7 @@
       "integrity": "sha512-LZKBjGovFRx3cRBkqmIg+BZnxbrLqhQl09IziMk3oeh1OV81Hg30RUIx885mq8qBv1PA0comB9bjKcuyNO1bCQ==",
       "dev": true,
       "requires": {
-        "pretty-format": "^24.5.0"
+        "pretty-format": "24.5.0"
       }
     },
     "jest-matcher-utils": {
@@ -2370,10 +2370,10 @@
       "integrity": "sha512-QM1nmLROjLj8GMGzg5VBra3I9hLpjMPtF1YqzQS3rvWn2ltGZLrGAO1KQ9zUCVi5aCvrkbS5Ndm2evIP9yZg1Q==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1",
-        "jest-diff": "^24.5.0",
-        "jest-get-type": "^24.3.0",
-        "pretty-format": "^24.5.0"
+        "chalk": "2.4.2",
+        "jest-diff": "24.5.0",
+        "jest-get-type": "24.3.0",
+        "pretty-format": "24.5.0"
       }
     },
     "jest-message-util": {
@@ -2382,14 +2382,14 @@
       "integrity": "sha512-6ZYgdOojowCGiV0D8WdgctZEAe+EcFU+KrVds+0ZjvpZurUW2/oKJGltJ6FWY2joZwYXN5VL36GPV6pNVRqRnQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@jest/test-result": "^24.5.0",
-        "@jest/types": "^24.5.0",
-        "@types/stack-utils": "^1.0.1",
-        "chalk": "^2.0.1",
-        "micromatch": "^3.1.10",
-        "slash": "^2.0.0",
-        "stack-utils": "^1.0.1"
+        "@babel/code-frame": "7.0.0",
+        "@jest/test-result": "24.5.0",
+        "@jest/types": "24.5.0",
+        "@types/stack-utils": "1.0.1",
+        "chalk": "2.4.2",
+        "micromatch": "3.1.10",
+        "slash": "2.0.0",
+        "stack-utils": "1.0.2"
       }
     },
     "jest-mock": {
@@ -2398,7 +2398,7 @@
       "integrity": "sha512-ZnAtkWrKf48eERgAOiUxVoFavVBziO2pAi2MfZ1+bGXVkDfxWLxU0//oJBkgwbsv6OAmuLBz4XFFqvCFMqnGUw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.5.0"
+        "@jest/types": "24.5.0"
       }
     },
     "jest-pnp-resolver": {
@@ -2419,11 +2419,11 @@
       "integrity": "sha512-ZIfGqLX1Rg8xJpQqNjdoO8MuxHV1q/i2OO1hLXjgCWFWs5bsedS8UrOdgjUqqNae6DXA+pCyRmdcB7lQEEbXew==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.5.0",
-        "browser-resolve": "^1.11.3",
-        "chalk": "^2.0.1",
-        "jest-pnp-resolver": "^1.2.1",
-        "realpath-native": "^1.1.0"
+        "@jest/types": "24.5.0",
+        "browser-resolve": "1.11.3",
+        "chalk": "2.4.2",
+        "jest-pnp-resolver": "1.2.1",
+        "realpath-native": "1.1.0"
       }
     },
     "jest-resolve-dependencies": {
@@ -2432,9 +2432,9 @@
       "integrity": "sha512-dRVM1D+gWrFfrq2vlL5P9P/i8kB4BOYqYf3S7xczZ+A6PC3SgXYSErX/ScW/469pWMboM1uAhgLF+39nXlirCQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.5.0",
-        "jest-regex-util": "^24.3.0",
-        "jest-snapshot": "^24.5.0"
+        "@jest/types": "24.5.0",
+        "jest-regex-util": "24.3.0",
+        "jest-snapshot": "24.5.0"
       }
     },
     "jest-runner": {
@@ -2443,25 +2443,25 @@
       "integrity": "sha512-oqsiS9TkIZV5dVkD+GmbNfWBRPIvxqmlTQ+AQUJUQ07n+4xTSDc40r+aKBynHw9/tLzafC00DIbJjB2cOZdvMA==",
       "dev": true,
       "requires": {
-        "@jest/console": "^24.3.0",
-        "@jest/environment": "^24.5.0",
-        "@jest/test-result": "^24.5.0",
-        "@jest/types": "^24.5.0",
-        "chalk": "^2.4.2",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.1.15",
-        "jest-config": "^24.5.0",
-        "jest-docblock": "^24.3.0",
-        "jest-haste-map": "^24.5.0",
-        "jest-jasmine2": "^24.5.0",
-        "jest-leak-detector": "^24.5.0",
-        "jest-message-util": "^24.5.0",
-        "jest-resolve": "^24.5.0",
-        "jest-runtime": "^24.5.0",
-        "jest-util": "^24.5.0",
-        "jest-worker": "^24.4.0",
-        "source-map-support": "^0.5.6",
-        "throat": "^4.0.0"
+        "@jest/console": "24.3.0",
+        "@jest/environment": "24.5.0",
+        "@jest/test-result": "24.5.0",
+        "@jest/types": "24.5.0",
+        "chalk": "2.4.2",
+        "exit": "0.1.2",
+        "graceful-fs": "4.1.15",
+        "jest-config": "24.5.0",
+        "jest-docblock": "24.3.0",
+        "jest-haste-map": "24.5.0",
+        "jest-jasmine2": "24.5.0",
+        "jest-leak-detector": "24.5.0",
+        "jest-message-util": "24.5.0",
+        "jest-resolve": "24.5.0",
+        "jest-runtime": "24.5.0",
+        "jest-util": "24.5.0",
+        "jest-worker": "24.4.0",
+        "source-map-support": "0.5.11",
+        "throat": "4.1.0"
       }
     },
     "jest-runtime": {
@@ -2470,29 +2470,29 @@
       "integrity": "sha512-GTFHzfLdwpaeoDPilNpBrorlPoNZuZrwKKzKJs09vWwHo+9TOsIIuszK8cWOuKC7ss07aN1922Ge8fsGdsqCuw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^24.3.0",
-        "@jest/environment": "^24.5.0",
-        "@jest/source-map": "^24.3.0",
-        "@jest/transform": "^24.5.0",
-        "@jest/types": "^24.5.0",
-        "@types/yargs": "^12.0.2",
-        "chalk": "^2.0.1",
-        "exit": "^0.1.2",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.1.15",
-        "jest-config": "^24.5.0",
-        "jest-haste-map": "^24.5.0",
-        "jest-message-util": "^24.5.0",
-        "jest-mock": "^24.5.0",
-        "jest-regex-util": "^24.3.0",
-        "jest-resolve": "^24.5.0",
-        "jest-snapshot": "^24.5.0",
-        "jest-util": "^24.5.0",
-        "jest-validate": "^24.5.0",
-        "realpath-native": "^1.1.0",
-        "slash": "^2.0.0",
-        "strip-bom": "^3.0.0",
-        "yargs": "^12.0.2"
+        "@jest/console": "24.3.0",
+        "@jest/environment": "24.5.0",
+        "@jest/source-map": "24.3.0",
+        "@jest/transform": "24.5.0",
+        "@jest/types": "24.5.0",
+        "@types/yargs": "12.0.10",
+        "chalk": "2.4.2",
+        "exit": "0.1.2",
+        "glob": "7.1.3",
+        "graceful-fs": "4.1.15",
+        "jest-config": "24.5.0",
+        "jest-haste-map": "24.5.0",
+        "jest-message-util": "24.5.0",
+        "jest-mock": "24.5.0",
+        "jest-regex-util": "24.3.0",
+        "jest-resolve": "24.5.0",
+        "jest-snapshot": "24.5.0",
+        "jest-util": "24.5.0",
+        "jest-validate": "24.5.0",
+        "realpath-native": "1.1.0",
+        "slash": "2.0.0",
+        "strip-bom": "3.0.0",
+        "yargs": "12.0.5"
       }
     },
     "jest-serializer": {
@@ -2507,18 +2507,18 @@
       "integrity": "sha512-eBEeJb5ROk0NcpodmSKnCVgMOo+Qsu5z9EDl3tGffwPzK1yV37mjGWF2YeIz1NkntgTzP+fUL4s09a0+0dpVWA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0",
-        "@jest/types": "^24.5.0",
-        "chalk": "^2.0.1",
-        "expect": "^24.5.0",
-        "jest-diff": "^24.5.0",
-        "jest-matcher-utils": "^24.5.0",
-        "jest-message-util": "^24.5.0",
-        "jest-resolve": "^24.5.0",
-        "mkdirp": "^0.5.1",
-        "natural-compare": "^1.4.0",
-        "pretty-format": "^24.5.0",
-        "semver": "^5.5.0"
+        "@babel/types": "7.4.0",
+        "@jest/types": "24.5.0",
+        "chalk": "2.4.2",
+        "expect": "24.5.0",
+        "jest-diff": "24.5.0",
+        "jest-matcher-utils": "24.5.0",
+        "jest-message-util": "24.5.0",
+        "jest-resolve": "24.5.0",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "pretty-format": "24.5.0",
+        "semver": "5.6.0"
       }
     },
     "jest-util": {
@@ -2527,19 +2527,19 @@
       "integrity": "sha512-Xy8JsD0jvBz85K7VsTIQDuY44s+hYJyppAhcsHsOsGisVtdhar6fajf2UOf2mEVEgh15ZSdA0zkCuheN8cbr1Q==",
       "dev": true,
       "requires": {
-        "@jest/console": "^24.3.0",
-        "@jest/fake-timers": "^24.5.0",
-        "@jest/source-map": "^24.3.0",
-        "@jest/test-result": "^24.5.0",
-        "@jest/types": "^24.5.0",
-        "@types/node": "*",
-        "callsites": "^3.0.0",
-        "chalk": "^2.0.1",
-        "graceful-fs": "^4.1.15",
-        "is-ci": "^2.0.0",
-        "mkdirp": "^0.5.1",
-        "slash": "^2.0.0",
-        "source-map": "^0.6.0"
+        "@jest/console": "24.3.0",
+        "@jest/fake-timers": "24.5.0",
+        "@jest/source-map": "24.3.0",
+        "@jest/test-result": "24.5.0",
+        "@jest/types": "24.5.0",
+        "@types/node": "11.11.6",
+        "callsites": "3.0.0",
+        "chalk": "2.4.2",
+        "graceful-fs": "4.1.15",
+        "is-ci": "2.0.0",
+        "mkdirp": "0.5.1",
+        "slash": "2.0.0",
+        "source-map": "0.6.1"
       }
     },
     "jest-validate": {
@@ -2548,12 +2548,12 @@
       "integrity": "sha512-gg0dYszxjgK2o11unSIJhkOFZqNRQbWOAB2/LOUdsd2LfD9oXiMeuee8XsT0iRy5EvSccBgB4h/9HRbIo3MHgQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.5.0",
-        "camelcase": "^5.0.0",
-        "chalk": "^2.0.1",
-        "jest-get-type": "^24.3.0",
-        "leven": "^2.1.0",
-        "pretty-format": "^24.5.0"
+        "@jest/types": "24.5.0",
+        "camelcase": "5.2.0",
+        "chalk": "2.4.2",
+        "jest-get-type": "24.3.0",
+        "leven": "2.1.0",
+        "pretty-format": "24.5.0"
       }
     },
     "jest-watcher": {
@@ -2562,14 +2562,14 @@
       "integrity": "sha512-/hCpgR6bg0nKvD3nv4KasdTxuhwfViVMHUATJlnGCD0r1QrmIssimPbmc5KfAQblAVxkD8xrzuij9vfPUk1/rA==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^24.5.0",
-        "@jest/types": "^24.5.0",
-        "@types/node": "*",
-        "@types/yargs": "^12.0.9",
-        "ansi-escapes": "^3.0.0",
-        "chalk": "^2.0.1",
-        "jest-util": "^24.5.0",
-        "string-length": "^2.0.0"
+        "@jest/test-result": "24.5.0",
+        "@jest/types": "24.5.0",
+        "@types/node": "11.11.6",
+        "@types/yargs": "12.0.10",
+        "ansi-escapes": "3.2.0",
+        "chalk": "2.4.2",
+        "jest-util": "24.5.0",
+        "string-length": "2.0.0"
       }
     },
     "jest-worker": {
@@ -2578,9 +2578,9 @@
       "integrity": "sha512-BH9X/klG9vxwoO99ZBUbZFfV8qO0XNZ5SIiCyYK2zOuJBl6YJVAeNIQjcoOVNu4HGEHeYEKsUWws8kSlSbZ9YQ==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
-        "merge-stream": "^1.0.1",
-        "supports-color": "^6.1.0"
+        "@types/node": "11.11.6",
+        "merge-stream": "1.0.1",
+        "supports-color": "6.1.0"
       },
       "dependencies": {
         "supports-color": {
@@ -2589,7 +2589,7 @@
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -2606,8 +2606,8 @@
       "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "jsbn": {
@@ -2622,32 +2622,32 @@
       "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
       "dev": true,
       "requires": {
-        "abab": "^2.0.0",
-        "acorn": "^5.5.3",
-        "acorn-globals": "^4.1.0",
-        "array-equal": "^1.0.0",
-        "cssom": ">= 0.3.2 < 0.4.0",
-        "cssstyle": "^1.0.0",
-        "data-urls": "^1.0.0",
-        "domexception": "^1.0.1",
-        "escodegen": "^1.9.1",
-        "html-encoding-sniffer": "^1.0.2",
-        "left-pad": "^1.3.0",
-        "nwsapi": "^2.0.7",
+        "abab": "2.0.0",
+        "acorn": "5.7.3",
+        "acorn-globals": "4.3.0",
+        "array-equal": "1.0.0",
+        "cssom": "0.3.6",
+        "cssstyle": "1.2.1",
+        "data-urls": "1.1.0",
+        "domexception": "1.0.1",
+        "escodegen": "1.11.1",
+        "html-encoding-sniffer": "1.0.2",
+        "left-pad": "1.3.0",
+        "nwsapi": "2.1.1",
         "parse5": "4.0.0",
-        "pn": "^1.1.0",
-        "request": "^2.87.0",
-        "request-promise-native": "^1.0.5",
-        "sax": "^1.2.4",
-        "symbol-tree": "^3.2.2",
-        "tough-cookie": "^2.3.4",
-        "w3c-hr-time": "^1.0.1",
-        "webidl-conversions": "^4.0.2",
-        "whatwg-encoding": "^1.0.3",
-        "whatwg-mimetype": "^2.1.0",
-        "whatwg-url": "^6.4.1",
-        "ws": "^5.2.0",
-        "xml-name-validator": "^3.0.0"
+        "pn": "1.1.0",
+        "request": "2.88.0",
+        "request-promise-native": "1.0.7",
+        "sax": "1.2.4",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.5.0",
+        "w3c-hr-time": "1.0.1",
+        "webidl-conversions": "4.0.2",
+        "whatwg-encoding": "1.0.5",
+        "whatwg-mimetype": "2.3.0",
+        "whatwg-url": "6.5.0",
+        "ws": "5.2.2",
+        "xml-name-validator": "3.0.0"
       }
     },
     "jsesc": {
@@ -2686,7 +2686,7 @@
       "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.0"
+        "minimist": "1.2.0"
       }
     },
     "jsprim": {
@@ -2719,7 +2719,7 @@
       "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "dev": true,
       "requires": {
-        "invert-kv": "^2.0.0"
+        "invert-kv": "2.0.0"
       }
     },
     "left-pad": {
@@ -2740,8 +2740,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "load-json-file": {
@@ -2750,10 +2750,10 @@
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.1.15",
+        "parse-json": "4.0.0",
+        "pify": "3.0.0",
+        "strip-bom": "3.0.0"
       }
     },
     "locate-path": {
@@ -2762,8 +2762,8 @@
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
       "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "3.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -2784,7 +2784,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "js-tokens": "4.0.0"
       }
     },
     "make-dir": {
@@ -2793,7 +2793,7 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "make-error": {
@@ -2808,7 +2808,7 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.x"
+        "tmpl": "1.0.4"
       }
     },
     "map-age-cleaner": {
@@ -2817,7 +2817,7 @@
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "dev": true,
       "requires": {
-        "p-defer": "^1.0.0"
+        "p-defer": "1.0.0"
       }
     },
     "map-cache": {
@@ -2832,7 +2832,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "mem": {
@@ -2841,9 +2841,9 @@
       "integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
       "dev": true,
       "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^2.0.0",
-        "p-is-promise": "^2.0.0"
+        "map-age-cleaner": "0.1.3",
+        "mimic-fn": "2.0.0",
+        "p-is-promise": "2.0.0"
       }
     },
     "merge-stream": {
@@ -2852,7 +2852,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.0.1"
+        "readable-stream": "2.3.6"
       }
     },
     "micromatch": {
@@ -2861,19 +2861,19 @@
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "braces": "2.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "extglob": "2.0.4",
+        "fragment-cache": "0.2.1",
+        "kind-of": "6.0.2",
+        "nanomatch": "1.2.13",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "mime-db": {
@@ -2888,7 +2888,7 @@
       "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.38.0"
+        "mime-db": "1.38.0"
       }
     },
     "mimic-fn": {
@@ -2903,7 +2903,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -2918,8 +2918,8 @@
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -2928,7 +2928,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -2962,17 +2962,17 @@
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       }
     },
     "natural-compare": {
@@ -3011,11 +3011,11 @@
       "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
       "dev": true,
       "requires": {
-        "growly": "^1.3.0",
-        "is-wsl": "^1.1.0",
-        "semver": "^5.5.0",
-        "shellwords": "^0.1.1",
-        "which": "^1.3.0"
+        "growly": "1.3.0",
+        "is-wsl": "1.1.0",
+        "semver": "5.6.0",
+        "shellwords": "0.1.1",
+        "which": "1.3.1"
       }
     },
     "normalize-package-data": {
@@ -3024,10 +3024,10 @@
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.7.1",
+        "resolve": "1.10.0",
+        "semver": "5.6.0",
+        "validate-npm-package-license": "3.0.4"
       }
     },
     "normalize-path": {
@@ -3036,7 +3036,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "npm-run-path": {
@@ -3045,7 +3045,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "number-is-nan": {
@@ -3072,9 +3072,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -3083,7 +3083,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "kind-of": {
@@ -3092,7 +3092,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -3109,7 +3109,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       }
     },
     "object.getownpropertydescriptors": {
@@ -3118,8 +3118,8 @@
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.13.0"
       }
     },
     "object.pick": {
@@ -3128,7 +3128,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "once": {
@@ -3137,7 +3137,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "optimist": {
@@ -3146,8 +3146,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
       },
       "dependencies": {
         "minimist": {
@@ -3164,12 +3164,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -3186,9 +3186,9 @@
       "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
       "dev": true,
       "requires": {
-        "execa": "^1.0.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
+        "execa": "1.0.0",
+        "lcid": "2.0.0",
+        "mem": "4.2.0"
       }
     },
     "p-defer": {
@@ -3203,7 +3203,7 @@
       "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
       "dev": true,
       "requires": {
-        "p-reduce": "^1.0.0"
+        "p-reduce": "1.0.0"
       }
     },
     "p-finally": {
@@ -3224,7 +3224,7 @@
       "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
       "dev": true,
       "requires": {
-        "p-try": "^2.0.0"
+        "p-try": "2.1.0"
       }
     },
     "p-locate": {
@@ -3233,7 +3233,7 @@
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
       "requires": {
-        "p-limit": "^2.0.0"
+        "p-limit": "2.2.0"
       }
     },
     "p-reduce": {
@@ -3254,8 +3254,8 @@
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
+        "error-ex": "1.3.2",
+        "json-parse-better-errors": "1.0.2"
       }
     },
     "parse5": {
@@ -3300,7 +3300,7 @@
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "performance-now": {
@@ -3321,7 +3321,7 @@
       "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
       "dev": true,
       "requires": {
-        "node-modules-regexp": "^1.0.0"
+        "node-modules-regexp": "1.0.0"
       }
     },
     "pkg-dir": {
@@ -3330,7 +3330,7 @@
       "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
       "dev": true,
       "requires": {
-        "find-up": "^3.0.0"
+        "find-up": "3.0.0"
       }
     },
     "pn": {
@@ -3357,10 +3357,10 @@
       "integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^24.5.0",
-        "ansi-regex": "^4.0.0",
-        "ansi-styles": "^3.2.0",
-        "react-is": "^16.8.4"
+        "@jest/types": "24.5.0",
+        "ansi-regex": "4.1.0",
+        "ansi-styles": "3.2.1",
+        "react-is": "16.8.5"
       }
     },
     "process-nextick-args": {
@@ -3375,8 +3375,8 @@
       "integrity": "sha512-HTzM3UWp/99A0gk51gAegwo1QRYA7xjcZufMNe33rCclFszUYAuHe1fIN/3ZmiHeGPkUsNaRyQm1hHOfM0PKxA==",
       "dev": true,
       "requires": {
-        "kleur": "^3.0.2",
-        "sisteransi": "^1.0.0"
+        "kleur": "3.0.2",
+        "sisteransi": "1.0.0"
       }
     },
     "psl": {
@@ -3391,8 +3391,8 @@
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       }
     },
     "punycode": {
@@ -3419,9 +3419,9 @@
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
       "dev": true,
       "requires": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
+        "load-json-file": "4.0.0",
+        "normalize-package-data": "2.5.0",
+        "path-type": "3.0.0"
       }
     },
     "read-pkg-up": {
@@ -3430,8 +3430,8 @@
       "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
       "dev": true,
       "requires": {
-        "find-up": "^3.0.0",
-        "read-pkg": "^3.0.0"
+        "find-up": "3.0.0",
+        "read-pkg": "3.0.0"
       }
     },
     "readable-stream": {
@@ -3440,13 +3440,13 @@
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "realpath-native": {
@@ -3455,7 +3455,7 @@
       "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
       "dev": true,
       "requires": {
-        "util.promisify": "^1.0.0"
+        "util.promisify": "1.0.0"
       }
     },
     "regex-not": {
@@ -3464,8 +3464,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "remove-trailing-separator": {
@@ -3492,26 +3492,26 @@
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.8.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.7",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.3",
+        "har-validator": "5.1.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.22",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.4.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       },
       "dependencies": {
         "punycode": {
@@ -3526,8 +3526,8 @@
           "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "dev": true,
           "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
+            "psl": "1.1.31",
+            "punycode": "1.4.1"
           }
         }
       }
@@ -3538,7 +3538,7 @@
       "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.11"
+        "lodash": "4.17.11"
       }
     },
     "request-promise-native": {
@@ -3548,8 +3548,8 @@
       "dev": true,
       "requires": {
         "request-promise-core": "1.1.2",
-        "stealthy-require": "^1.1.1",
-        "tough-cookie": "^2.3.3"
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.5.0"
       }
     },
     "require-directory": {
@@ -3570,7 +3570,7 @@
       "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.6"
+        "path-parse": "1.0.6"
       }
     },
     "resolve-cwd": {
@@ -3579,7 +3579,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "3.0.0"
       }
     },
     "resolve-from": {
@@ -3606,7 +3606,7 @@
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.3"
+        "glob": "7.1.3"
       }
     },
     "rsvp": {
@@ -3627,7 +3627,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -3642,15 +3642,15 @@
       "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
       "dev": true,
       "requires": {
-        "@cnakazawa/watch": "^1.0.3",
-        "anymatch": "^2.0.0",
-        "capture-exit": "^2.0.0",
-        "exec-sh": "^0.3.2",
-        "execa": "^1.0.0",
-        "fb-watchman": "^2.0.0",
-        "micromatch": "^3.1.4",
-        "minimist": "^1.1.1",
-        "walker": "~1.0.5"
+        "@cnakazawa/watch": "1.0.3",
+        "anymatch": "2.0.0",
+        "capture-exit": "2.0.0",
+        "exec-sh": "0.3.2",
+        "execa": "1.0.0",
+        "fb-watchman": "2.0.0",
+        "micromatch": "3.1.10",
+        "minimist": "1.2.0",
+        "walker": "1.0.7"
       }
     },
     "sax": {
@@ -3677,10 +3677,10 @@
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -3689,7 +3689,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -3700,7 +3700,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -3739,14 +3739,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -3755,7 +3755,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -3764,7 +3764,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "source-map": {
@@ -3781,9 +3781,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -3792,7 +3792,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -3801,7 +3801,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-data-descriptor": {
@@ -3810,7 +3810,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.2"
           }
         },
         "is-descriptor": {
@@ -3819,9 +3819,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
           }
         }
       }
@@ -3832,7 +3832,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -3841,7 +3841,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -3858,11 +3858,11 @@
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
-        "atob": "^2.1.1",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.2",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -3871,8 +3871,8 @@
       "integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
+        "buffer-from": "1.1.1",
+        "source-map": "0.6.1"
       }
     },
     "source-map-url": {
@@ -3887,8 +3887,8 @@
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.3"
       }
     },
     "spdx-exceptions": {
@@ -3903,8 +3903,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.2.0",
+        "spdx-license-ids": "3.0.3"
       }
     },
     "spdx-license-ids": {
@@ -3919,7 +3919,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "sprintf-js": {
@@ -3934,15 +3934,15 @@
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "stack-utils": {
@@ -3957,8 +3957,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -3967,7 +3967,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -3984,8 +3984,8 @@
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "dev": true,
       "requires": {
-        "astral-regex": "^1.0.0",
-        "strip-ansi": "^4.0.0"
+        "astral-regex": "1.0.0",
+        "strip-ansi": "4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4000,7 +4000,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -4011,8 +4011,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4027,7 +4027,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -4038,7 +4038,7 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "strip-ansi": {
@@ -4047,7 +4047,7 @@
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^4.1.0"
+        "ansi-regex": "4.1.0"
       }
     },
     "strip-bom": {
@@ -4068,7 +4068,7 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "symbol-tree": {
@@ -4083,10 +4083,10 @@
       "integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "minimatch": "^3.0.4",
-        "read-pkg-up": "^4.0.0",
-        "require-main-filename": "^1.0.1"
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "4.0.0",
+        "require-main-filename": "1.0.1"
       }
     },
     "throat": {
@@ -4113,7 +4113,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "kind-of": {
@@ -4122,7 +4122,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -4133,10 +4133,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -4145,8 +4145,8 @@
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
       }
     },
     "tough-cookie": {
@@ -4155,8 +4155,8 @@
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
+        "psl": "1.1.31",
+        "punycode": "2.1.1"
       }
     },
     "tr46": {
@@ -4165,7 +4165,7 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "trim-right": {
@@ -4180,15 +4180,15 @@
       "integrity": "sha512-o8BO3TkMREpAATaFTrXkovMsCpBl2z4NDBoLJuWZcJJj1ijI49UnvDMfVpj+iogn/Jl8Pbhuei5nc/Ti+frEHw==",
       "dev": true,
       "requires": {
-        "bs-logger": "0.x",
-        "buffer-from": "1.x",
-        "fast-json-stable-stringify": "2.x",
-        "json5": "2.x",
-        "make-error": "1.x",
-        "mkdirp": "0.x",
-        "resolve": "1.x",
-        "semver": "^5.5",
-        "yargs-parser": "10.x"
+        "bs-logger": "0.2.6",
+        "buffer-from": "1.1.1",
+        "fast-json-stable-stringify": "2.0.0",
+        "json5": "2.1.0",
+        "make-error": "1.3.5",
+        "mkdirp": "0.5.1",
+        "resolve": "1.10.0",
+        "semver": "5.6.0",
+        "yargs-parser": "10.1.0"
       },
       "dependencies": {
         "camelcase": {
@@ -4203,7 +4203,7 @@
           "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }
@@ -4214,7 +4214,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -4229,7 +4229,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "typescript": {
@@ -4245,8 +4245,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.19.0",
-        "source-map": "~0.6.1"
+        "commander": "2.19.0",
+        "source-map": "0.6.1"
       }
     },
     "union-value": {
@@ -4255,10 +4255,10 @@
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
       },
       "dependencies": {
         "extend-shallow": {
@@ -4267,7 +4267,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "set-value": {
@@ -4276,10 +4276,10 @@
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
           }
         }
       }
@@ -4290,8 +4290,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -4300,9 +4300,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -4330,7 +4330,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "urix": {
@@ -4357,8 +4357,8 @@
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
+        "define-properties": "1.1.3",
+        "object.getownpropertydescriptors": "2.0.3"
       }
     },
     "uuid": {
@@ -4373,8 +4373,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.1.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "verror": {
@@ -4383,9 +4383,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "w3c-hr-time": {
@@ -4394,7 +4394,7 @@
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "dev": true,
       "requires": {
-        "browser-process-hrtime": "^0.1.2"
+        "browser-process-hrtime": "0.1.3"
       }
     },
     "walker": {
@@ -4403,7 +4403,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
-        "makeerror": "1.0.x"
+        "makeerror": "1.0.11"
       }
     },
     "webidl-conversions": {
@@ -4433,9 +4433,9 @@
       "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
       "dev": true,
       "requires": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
       }
     },
     "which": {
@@ -4444,7 +4444,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -4465,8 +4465,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4481,7 +4481,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -4490,9 +4490,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-ansi": {
@@ -4501,7 +4501,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -4518,9 +4518,9 @@
       "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.15",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "ws": {
@@ -4529,7 +4529,7 @@
       "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
       "dev": true,
       "requires": {
-        "async-limiter": "~1.0.0"
+        "async-limiter": "1.0.0"
       }
     },
     "xml-name-validator": {
@@ -4550,18 +4550,18 @@
       "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
       "dev": true,
       "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^3.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1 || ^4.0.0",
-        "yargs-parser": "^11.1.1"
+        "cliui": "4.1.0",
+        "decamelize": "1.2.0",
+        "find-up": "3.0.0",
+        "get-caller-file": "1.0.3",
+        "os-locale": "3.1.0",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "2.1.1",
+        "which-module": "2.0.0",
+        "y18n": "4.0.0",
+        "yargs-parser": "11.1.1"
       }
     },
     "yargs-parser": {
@@ -4570,8 +4570,8 @@
       "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
       "dev": true,
       "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+        "camelcase": "5.2.0",
+        "decamelize": "1.2.0"
       }
     }
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,6 +20,14 @@ object Dependencies {
     )
   }
 
+  val playLibs_2_8 = {
+    val version = "2.8.1"
+    Seq(
+      "com.typesafe.play" %% "play" % version % "provided",
+      "com.typesafe.play" %% "play-ws" % version % "provided"
+    )
+  }
+
   val googleDirectoryApiDependencies = Seq(
     "com.google.api-client" % "google-api-client" % "1.28.0",
     "com.google.apis" % "google-api-services-admin" % "directory_v1-rev32-1.16.0-rc"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.11")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.2")
 


### PR DESCRIPTION
The code is a copy paste from Play 2.7 which means that version may well work directly with Play 2.8 but I think it's clearer if we publish a separate artifact anyway.

Further updates I think are worth doing in separate PRs:
- Cross build against Scala 2.12 and 2.13
- Upgrade to SBT v1
- General library version bumps