### PR TITLE
setApplicationName in credential builder to stop it complaining

### DIFF
--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/service/Google2FAGroupChecker.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/service/Google2FAGroupChecker.scala
@@ -22,6 +22,7 @@ class GroupChecker(config: Google2FAGroupSettings, bucketName: String, s3Client:
     .setServiceAccountScopes(List(DirectoryScopes.ADMIN_DIRECTORY_GROUP_READONLY).asJavaCollection)
     .setServiceAccountUser(config.adminUserEmail)
     .setServiceAccountPrivateKey(loadServiceAccountPrivateKey)
+    .setApplicationName(appName)
     .build()
 
   val directory = new Directory.Builder(transport, jsonFactory, null)


### PR DESCRIPTION
see #60 

@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->