### PR TITLE
Add support for the "hd" parameter for Google

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ com_crashlytics_export_strings.xml
 # Frontend
 **/node_modules/*
 */public/jspm_packages/*
+.bloop
+project/metals.sbt

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ cookieName=exampleAuth
 
 clientId=example_oauth_client_id
 clientSecret=example_oauth_secret
+organizationDomain=example.com
 
 googleServiceAccountId=serviceAccount@developer.gserviceaccount.com
 googleServiceAccountCert=name_of_cert_in_bucket.p12
@@ -139,7 +140,11 @@ publicKey=example_key
 
 * **clientId** - this is the OAuth client id for the provider you are authenticating against
 
-* **googleAuthSecret** - this is the OAuth secret for the provider
+* **clientSecret** - this is the OAuth secret for the provider
+
+* **organizationDomain** - OPTIONAL: this is the domain where users are registered, for services which support it. If user's emails are in the format `user@example.com`, then this should be set to `example.com`.
+  * Known services with support: 
+    * Google
 
 * **googleServiceAccountId, googleServiceAccountCert, google2faUser and multifactorGroupId** - these are optional parameters for using a group based 2 factor auth verification
 

--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/PanDomainAuthSettings.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/PanDomainAuthSettings.scala
@@ -17,7 +17,8 @@ case class CookieSettings(
 case class OAuthSettings(
   clientId: String,
   clientSecret: String,
-  discoveryDocumentUrl: String
+  discoveryDocumentUrl: String,
+  organizationDomain: Option[String]
 )
 
 case class Google2FAGroupSettings(
@@ -38,7 +39,8 @@ object PanDomainAuthSettings{
     val oAuthSettings = OAuthSettings(
       settingMap("clientId"),
       settingMap("clientSecret"),
-      settingMap("discoveryDocumentUrl")
+      settingMap("discoveryDocumentUrl"),
+      settingMap.get("organizationDomain")
     )
 
     val google2faSettings = for(

--- a/pan-domain-auth-play_2-7/src/main/scala/com/gu/pandomainauth/service/OAuth.scala
+++ b/pan-domain-auth-play_2-7/src/main/scala/com/gu/pandomainauth/service/OAuth.scala
@@ -52,7 +52,7 @@ class OAuth(config: OAuthSettings, system: String, redirectUrl: String) {
       "scope" -> Seq("openid email profile"),
       "redirect_uri" -> Seq(redirectUrl),
       "state" -> Seq(antiForgeryToken)
-    ) ++ email.map("login_hint" -> Seq(_))
+    ) ++ email.map("login_hint" -> Seq(_)) ++ config.organizationDomain.map("hd" -> Seq(_))
 
     discoveryDocument.map(dd => Redirect(s"${dd.authorization_endpoint}", queryString))
   }

--- a/pan-domain-auth-play_2-8/src/main/scala/com/gu/pandomainauth/service/OAuth.scala
+++ b/pan-domain-auth-play_2-8/src/main/scala/com/gu/pandomainauth/service/OAuth.scala
@@ -52,7 +52,7 @@ class OAuth(config: OAuthSettings, system: String, redirectUrl: String) {
       "scope" -> Seq("openid email profile"),
       "redirect_uri" -> Seq(redirectUrl),
       "state" -> Seq(antiForgeryToken)
-    ) ++ email.map("login_hint" -> Seq(_))
+    ) ++ email.map("login_hint" -> Seq(_)) ++ config.organizationDomain.map("hd" -> Seq(_))
 
     discoveryDocument.map(dd => Redirect(s"${dd.authorization_endpoint}", queryString))
   }


### PR DESCRIPTION
This parameter allows us to hint to Google which email address the user
is expected to authenticate with.  For example, if the user is signed
into two accounts and this parameter is set with "guardian.co.uk",
Google will automatically select the user's Guardian Google account.

See
<https://developers.google.com/identity/protocols/oauth2/openid-connect#hd-param>


@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->