### PR TITLE
Check membership of MFA group directly

### DIFF
--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/service/Google2FAGroupChecker.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/service/Google2FAGroupChecker.scala
@@ -46,6 +46,7 @@ class GroupChecker(config: Google2FAGroupSettings, bucketName: String, s3Client:
     val hasGroupOnPage = Option(groupsResponse.getGroups).exists(_.asScala.exists(_.getEmail == groupId))
     hasGroupOnPage || (if(hasMoreGroups(groupsResponse)) hasGroup( query.setPageToken(groupsResponse.getNextPageToken), groupId ) else false)
   }
+  protected def hasGroup(userEmail: String, groupId: String): Boolean = directory.members().hasMember(groupId, userEmail).execute().getIsMember()
 
   private def hasMoreGroups(groupsResponse: Groups): Boolean = {
     val token = groupsResponse.getNextPageToken
@@ -66,8 +67,7 @@ class GoogleGroupChecker(config: Google2FAGroupSettings, bucketName: String, s3C
 class Google2FAGroupChecker(config: Google2FAGroupSettings, bucketName: String, s3Client: AmazonS3, appName: String) extends GroupChecker(config, bucketName, s3Client, appName) {
 
   def checkMultifactor(authenticatedUser: AuthenticatedUser): Boolean = {
-    val query = directory.groups().list().setUserKey(authenticatedUser.user.email)
-    hasGroup(query, config.multifactorGroupId)
+    hasGroup(authenticatedUser.user.email, config.multifactorGroupId)
   }
 
 }


### PR DESCRIPTION
@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->

Switch the google API call for the google mfa check from https://developers.google.com/admin-sdk/directory/reference/rest/v1/groups/list to https://developers.google.com/admin-sdk/directory/reference/rest/v1/members/hasMember 

This is due to a single user whose account seems to have received a bug - when querying the list of groups they're a member of we receive a 503 error. However we _are_ able to check if they're a member of the mfa group directly without any issue, so use that API method instead.

This is also probably a slight improvement without that context - instead of potentially needing to paginate through long lists of group memberships, we can ask our question directly.

I think we could also delete the `GoogleGroupChecker.checkGroups` method; I can't find any project in github.com/guardian which makes use of it. But that should probably be a separate PR. (deleting a class -> breaking change -> major version release...)

