### PR TITLE
Bump sbt to 1.7.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,10 +12,10 @@ val scala213 = "2.13.8"
 val commonSettings =
   Seq(
     scalaVersion := scala212,
-    scalaVersion in ThisBuild := scala212,
+    ThisBuild / scalaVersion  := scala212,
     crossScalaVersions := Seq(scalaVersion.value, scala213),
     organization := "com.gu",
-    fork in Test := false,
+    Test / fork := false,
     resolvers ++= Seq("Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/"),
     scalacOptions ++= Seq("-feature", "-deprecation", "-language:higherKinds", "-Xfatal-warnings"),
     publishArtifact := false
@@ -110,7 +110,7 @@ lazy val exampleApp = project("pan-domain-auth-example")
   .settings(sonatypeReleaseSettings: _*)
   .settings(
     publishArtifact := false,
-    skip in publish := true,
+    publish / skip := true,
     playDefaultPort := 9500
   )
 
@@ -123,7 +123,7 @@ lazy val root = Project("pan-domain-auth-root", file(".")).aggregate(
 ).settings(sonatypeReleaseSettings: _*).settings(
   organization := "com.gu",
   publishArtifact := false,
-  skip in publish := true,
+  publish / skip := true,
 )
 
 def project(path: String): Project =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val awsDependencies = Seq("com.amazonaws" % "aws-java-sdk-s3" % "1.11.835")
 
   val playLibs_2_7 = {
-    val version = "2.7.5"
+    val version = "2.7.9"
     Seq(
       "com.typesafe.play" %% "play" % version % "provided",
       "com.typesafe.play" %% "play-ws" % version % "provided"
@@ -13,7 +13,7 @@ object Dependencies {
   }
 
   val playLibs_2_8 = {
-    val version = "2.8.2"
+    val version = "2.8.19"
     Seq(
       "com.typesafe.play" %% "play" % version % "provided",
       "com.typesafe.play" %% "play-ws" % version % "provided"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.1-SNAPSHOT"
+ThisBuild / version := "1.2.1-SNAPSHOT"


### PR DESCRIPTION
## What's changed?

Bumps sbt to 1.7.2 – >1.4.x is necessary for the project to compile on M1 machines. I've also bumped the relevant Play libs, as Play 2.8 has problems with later versions of sbt that are [fixed in >2.8.8.](https://github.com/sbt/sbt/issues/6400)

## Why not latest (1.8.2 at time of writing)?

Bumping to latest pulls in two different major versions of scala-xml. There are [workarounds](https://github.com/sbt/sbt/issues/7007#issuecomment-1221823661) that IIUC involve handwaving this conflict, but given that this is an important dependency that touches many projects, perhaps that's best avoided.

[The latest version of Twirl uses scala-xml 2.x](https://github.com/playframework/twirl/blob/df5f7ef869f78b3da7109edee4966a8ec16bb19d/build.sbt#L89), which I think will be coming in Play 2.9, so I think we'll have to wait for Play 2.9 to resolve this without that workaround. If others would prefer us to bump sbt rather than wait, we can use the workaround above.
