### PR TITLE
Resolve high jackson-databind vulnerabilities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,6 @@ lazy val panDomainAuthVerification = project("pan-domain-auth-verification")
       ++= cryptoDependencies
       ++ awsDependencies
       ++ testDependencies
-      ++ jackson
       ++ loggingDependencies
       ++ scalaCollectionCompatDependencies,
     publishArtifact := true

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
 
-  val awsDependencies = Seq("com.amazonaws" % "aws-java-sdk-s3" % "1.11.835")
+  val awsDependencies = Seq("com.amazonaws" % "aws-java-sdk-s3" % "1.12.470")
 
   val playLibs_2_7 = {
     val version = "2.7.5"
@@ -38,20 +38,6 @@ object Dependencies {
   )
 
   val testDependencies = Seq("org.scalatest" %% "scalatest" % "3.2.0" % "test")
-
-  /*
-   * Pull in an updated version of jackson and logback libraries as the ones AWS use have security vulnerabilities.
-   * See https://github.com/aws/aws-sdk-java/pull/1373
-   *
-   * We also cannot upgrade beyond Jackson 2.10 as Akka depends on the Jackson Scala integration and requires < 2.11
-   */
-  val jackson: Seq[ModuleID] = {
-    Seq(
-      "com.fasterxml.jackson.core" % "jackson-core" % "2.10.5",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.5.1",
-      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.10.5"
-    )
-  }
 
   val loggingDependencies = Seq("org.slf4j" % "slf4j-api" % "1.7.30")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   }
 
   val playLibs_2_8 = {
-    val version = "2.8.2"
+    val version = "2.8.19"
     Seq(
       "com.typesafe.play" %% "play" % version % "provided",
       "com.typesafe.play" %% "play-ws" % version % "provided"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.2-SNAPSHOT"
+version in ThisBuild := "1.2.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.2"
+version in ThisBuild := "1.2.3-SNAPSHOT"


### PR DESCRIPTION
@guardian/digital-cms

This resolves some high vulnerabilities in the Jackson libraries which are brought in transitively via the AWS SDK. 

At least some of the vulnerabilities have been resolved on the AWS-side (https://github.com/aws/aws-sdk-java/issues/2726), so we can stop overriding these libraries and bump the AWS dependency instead.

Running `snyk test` locally shows the high vulnerabilities relating to jackson disappear when bumping the AWS SDK version and removing the manual overrides.

## How to test

Publish the library locally with `sbt "+publishLocal"`, and bump to the snapshot version in a consuming project. Does authentication work as expected?

This has been tested by publishing the library locally and logging into local Composer.