### PR TITLE
allow setting a cookie to force expiry early for debugging purposes

### DIFF
--- a/pan-domain-auth-example/app/VerifyExample.scala
+++ b/pan-domain-auth-example/app/VerifyExample.scala
@@ -44,7 +44,7 @@ object VerifyExample {
   val cacheValidation = false
 
   // To verify, call the authStatus method with the encoded cookie data
-  val status = PanDomain.authStatus("<<cookie data>>>", publicKey, validateUser, apiGracePeriod, system, cacheValidation)
+  val status = PanDomain.authStatus("<<cookie data>>>", publicKey, validateUser, apiGracePeriod, system, cacheValidation, forceExpiry = false)
 
   status match {
     case Authenticated(_) | GracePeriod(_) =>

--- a/pan-domain-auth-play_2-7/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-7/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -88,7 +88,14 @@ trait AuthActions {
     * A cookie key that stores the target URL that was being accessed when redirected for authentication
     */
   val LOGIN_ORIGIN_KEY = "panda-loginOriginUrl"
+  /*
+   * Cookie key containing an anti-forgery token; helps to validate that the oauth callback arrived in response to the correct oauth request
+   */
   val ANTI_FORGERY_KEY = "panda-antiForgeryToken"
+  /*
+   * Cookie that will make panda behave as if the cookie has expired.
+   * NOTE: This cookie is for debugging only! It should _not_ be set by any application code to expire the cookie!! Use the `processLogout` action instead!!
+   */
   private val FORCE_EXPIRY_KEY = "panda-forceExpiry"
 
   private def cookie(name: String, value: String): Cookie =

--- a/pan-domain-auth-play_2-8/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-8/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -88,7 +88,14 @@ trait AuthActions {
     * A cookie key that stores the target URL that was being accessed when redirected for authentication
     */
   val LOGIN_ORIGIN_KEY = "panda-loginOriginUrl"
+  /*
+   * Cookie key containing an anti-forgery token; helps to validate that the oauth callback arrived in response to the correct oauth request
+   */
   val ANTI_FORGERY_KEY = "panda-antiForgeryToken"
+  /*
+   * Cookie that will make panda behave as if the cookie has expired.
+   * NOTE: This cookie is for debugging only! It should _not_ be set by any application code to expire the cookie!! Use the `processLogout` action instead!!
+   */
   private val FORCE_EXPIRY_KEY = "panda-forceExpiry"
 
   private def cookie(name: String, value: String): Cookie =

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/PanDomainTest.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/PanDomainTest.scala
@@ -11,10 +11,15 @@ import org.scalatest.matchers.should.Matchers
 class PanDomainTest extends AnyFreeSpec with Matchers with Inside {
   import com.gu.pandomainauth.service.TestKeys._
 
-  val forceExpiry = false
 
-  def authStatus(cookieData: String, validateUser: AuthenticatedUser => Boolean = _ => true, apiGracePeriod: Long = 0,
-                 system: String = "testsuite", cacheValidation: Boolean = false) = {
+  def authStatus(
+    cookieData: String,
+    validateUser: AuthenticatedUser => Boolean = _ => true,
+    apiGracePeriod: Long = 0,
+    system: String = "testsuite",
+    cacheValidation: Boolean = false,
+    forceExpiry: Boolean = false,
+  ) = {
     PanDomain.authStatus(cookieData, testPublicKey, validateUser, apiGracePeriod, system, cacheValidation, forceExpiry)
   }
 
@@ -57,6 +62,11 @@ class PanDomainTest extends AnyFreeSpec with Matchers with Inside {
       val cookieData = CookieUtils.generateCookieData(expiredAuthUser, testPrivateKey)
 
       authStatus(cookieData) shouldBe a [Expired]
+    }
+
+    "returns `Expired` if cookie has not expired, but forceExpiry is set" in {
+      val validCookieData = CookieUtils.generateCookieData(authUser, testPrivateKey)
+      authStatus(validCookieData, forceExpiry = true) shouldBe a [Expired]
     }
 
     "returns `GracePeriod` if the cookie has expired but is within the grace period" in {

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/PanDomainTest.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/PanDomainTest.scala
@@ -11,9 +11,11 @@ import org.scalatest.matchers.should.Matchers
 class PanDomainTest extends AnyFreeSpec with Matchers with Inside {
   import com.gu.pandomainauth.service.TestKeys._
 
+  val forceExpiry = false
+
   def authStatus(cookieData: String, validateUser: AuthenticatedUser => Boolean = _ => true, apiGracePeriod: Long = 0,
                  system: String = "testsuite", cacheValidation: Boolean = false) = {
-    PanDomain.authStatus(cookieData, testPublicKey, validateUser, apiGracePeriod, system, cacheValidation)
+    PanDomain.authStatus(cookieData, testPublicKey, validateUser, apiGracePeriod, system, cacheValidation, forceExpiry)
   }
 
   "authStatus" - {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.7.2


### PR DESCRIPTION
@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->

## What does this change

This sets panda to watch out for a new cookie, `panda-forceExpiry`, which if set to a non-zero value, will make the panda library treat the presented panda cookie as if it had expired

## Why

There's been a few problems around quietly re-authenticating expired users onto tools recently, and I expect more to come in the future. Each time it has been frustrating to attempt to reproduce, because cookies only expire after 1hr. We can try to delete the cookie from our browser, but this presents the same as an entirely new user, which is a different and less problematic scenario. (An entirely new user should arrive onto a page via a page transition and receive a cookie then, whereas reauthenticating a user will often need to be done in response to an XHR, which browsers apply slightly different cookie security rules.

## Does this reduce security?

This is the important question. I believe it doesn't, as the only power this new cookie has to offer is to expire a valid cookie earlier, and only if the tool in question has been upgraded to this version of panda. This cookie also is not set by the panda library, so in effect requires to be set by a developer from devtools when debugging how an app will respond to an expired cookie.

- [x] Tested locally