### PR TITLE
Bad request for missing cookie

### DIFF
--- a/pan-domain-auth-play_2-7/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-7/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -142,11 +142,14 @@ trait AuthActions {
     */
   def invalidUserMessage(claimedAuth: AuthenticatedUser) = s"user ${claimedAuth.user.email} not valid for $system"
 
+  private def decodeCookie(name: String)(implicit request: RequestHeader) =
+    request.cookies.get(name).map(cookie => URLDecoder.decode(cookie.value, "UTF-8"))
+
   def processOAuthCallback()(implicit request: RequestHeader): Future[Result] = {
     val token =
-      request.cookies.get(ANTI_FORGERY_KEY).map(cookie => URLDecoder.decode(cookie.value, "UTF-8")).getOrElse(throw new OAuthException("missing anti forgery token"))
+      decodeCookie(ANTI_FORGERY_KEY).getOrElse(throw new OAuthException("missing anti forgery token"))
     val originalUrl =
-      request.cookies.get(LOGIN_ORIGIN_KEY).map(cookie => URLDecoder.decode(cookie.value, "UTF-8")).getOrElse(throw new OAuthException("missing original url"))
+      decodeCookie(LOGIN_ORIGIN_KEY).getOrElse(throw new OAuthException("missing original url"))
 
     val existingCookie = readCookie(request) // will be populated if this was a re-auth for expired login
 

--- a/pan-domain-auth-play_2-7/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-7/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -150,24 +150,24 @@ trait AuthActions {
       token <- decodeCookie(ANTI_FORGERY_KEY)
       originalUrl <- decodeCookie(LOGIN_ORIGIN_KEY)
     } yield {
-    OAuth.validatedUserIdentity(token)(request, ec, wsClient).map { claimedAuth =>
-      val existingAuthenticatedIn = readAuthenticatedUser(request).map(_.authenticatedIn)
-      val authedUserData =
+      OAuth.validatedUserIdentity(token)(request, ec, wsClient).map { claimedAuth =>
+        val existingAuthenticatedIn = readAuthenticatedUser(request).map(_.authenticatedIn)
+        val authedUserData =
           claimedAuth.copy(
             authenticatingSystem = system,
             authenticatedIn = existingAuthenticatedIn.fold(Set(system))(_ + system),
             multiFactor = checkMultifactor(claimedAuth)
           )
 
-      if (validateUser(authedUserData)) {
-        val updatedCookie = generateCookie(authedUserData)
-        Redirect(originalUrl)
-          .withCookies(updatedCookie)
-          .discardingCookies(discardCookies:_*)
-      } else {
-        showUnauthedMessage(invalidUserMessage(claimedAuth))
+        if (validateUser(authedUserData)) {
+          val updatedCookie = generateCookie(authedUserData)
+          Redirect(originalUrl)
+            .withCookies(updatedCookie)
+            .discardingCookies(discardCookies:_*)
+        } else {
+          showUnauthedMessage(invalidUserMessage(claimedAuth))
+        }
       }
-    }
     }) getOrElse {
       Future.successful(BadRequest("Missing cookies"))
     }

--- a/pan-domain-auth-play_2-8/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-8/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -142,11 +142,14 @@ trait AuthActions {
     */
   def invalidUserMessage(claimedAuth: AuthenticatedUser) = s"user ${claimedAuth.user.email} not valid for $system"
 
+  private def decodeCookie(name: String)(implicit request: RequestHeader) =
+    request.cookies.get(name).map(cookie => URLDecoder.decode(cookie.value, "UTF-8"))
+
   def processOAuthCallback()(implicit request: RequestHeader): Future[Result] = {
     val token =
-      request.cookies.get(ANTI_FORGERY_KEY).map(cookie => URLDecoder.decode(cookie.value, "UTF-8")).getOrElse(throw new OAuthException("missing anti forgery token"))
+      decodeCookie(ANTI_FORGERY_KEY).getOrElse(throw new OAuthException("missing anti forgery token"))
     val originalUrl =
-      request.cookies.get(LOGIN_ORIGIN_KEY).map(cookie => URLDecoder.decode(cookie.value, "UTF-8")).getOrElse(throw new OAuthException("missing original url"))
+      decodeCookie(LOGIN_ORIGIN_KEY).getOrElse(throw new OAuthException("missing original url"))
 
     val existingCookie = readCookie(request) // will be populated if this was a re-auth for expired login
 

--- a/pan-domain-auth-play_2-8/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play_2-8/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -150,24 +150,24 @@ trait AuthActions {
       token <- decodeCookie(ANTI_FORGERY_KEY)
       originalUrl <- decodeCookie(LOGIN_ORIGIN_KEY)
     } yield {
-    OAuth.validatedUserIdentity(token)(request, ec, wsClient).map { claimedAuth =>
-      val existingAuthenticatedIn = readAuthenticatedUser(request).map(_.authenticatedIn)
-      val authedUserData =
+      OAuth.validatedUserIdentity(token)(request, ec, wsClient).map { claimedAuth =>
+        val existingAuthenticatedIn = readAuthenticatedUser(request).map(_.authenticatedIn)
+        val authedUserData =
           claimedAuth.copy(
             authenticatingSystem = system,
             authenticatedIn = existingAuthenticatedIn.fold(Set(system))(_ + system),
             multiFactor = checkMultifactor(claimedAuth)
           )
 
-      if (validateUser(authedUserData)) {
-        val updatedCookie = generateCookie(authedUserData)
-        Redirect(originalUrl)
-          .withCookies(updatedCookie)
-          .discardingCookies(discardCookies:_*)
-      } else {
-        showUnauthedMessage(invalidUserMessage(claimedAuth))
+        if (validateUser(authedUserData)) {
+          val updatedCookie = generateCookie(authedUserData)
+          Redirect(originalUrl)
+            .withCookies(updatedCookie)
+            .discardingCookies(discardCookies:_*)
+        } else {
+          showUnauthedMessage(invalidUserMessage(claimedAuth))
+        }
       }
-    }
     }) getOrElse {
       Future.successful(BadRequest("Missing cookies"))
     }


### PR DESCRIPTION
DevX recommended modifying this library to serve a BadRequest (400) in the case of a missing cookie, instead of throwing an exception. This will avoid services looking like they are failing their availability SLI when users are making bad requests. 