### PR TITLE
Changes required to fully and correctly release 1.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,7 +129,8 @@ lazy val root = Project("pan-domain-auth-root", file(".")).aggregate(
   panDomainAuthPlay_2_9,
   panDomainAuthPlay_3_0,
   exampleApp
-).settings(
+).settings(sonatypeReleaseSettings)
+ .settings(
   organization := "com.gu",
   publishArtifact := false,
   publish / skip := true,

--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,7 @@ val sonatypeReleaseSettings = {
       url("https://github.com/guardian/pan-domain-authentication"),
       "scm:git:git@github.com:guardian/pan-domain-authentication.git"
     )),
+    homepage := Some(url("https://github.com/guardian/pan-domain-authentication")),
     developers := List(Developer(
       id = "GuardianEdTools",
       name = "Guardian Editorial Tools",

--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,7 @@ ThisBuild / scalaVersion := scala213
 
 val commonSettings =
   Seq(
-    scalaVersion := scala213,
-    crossScalaVersions := Seq(scalaVersion.value, scala212),
+    crossScalaVersions := List(scala212, scala213),
     organization := "com.gu",
     Test / fork := false,
     scalacOptions ++= Seq("-feature", "-deprecation", "-Xfatal-warnings"),
@@ -35,7 +34,7 @@ val sonatypeReleaseSettings = {
       email = "digitalcms.dev@theguardian.com",
       url = url("https://github.com/orgs/guardian/teams/digital-cms")
     )),
-    releaseCrossBuild := true,
+    releaseCrossBuild := false,
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,
       inquireVersions,

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,9 @@ val scala213 = "2.13.8"
 
 ThisBuild / scalaVersion := scala213
 
+// See below - the release process itself is correctly configured to publish the cross-built
+// subprojects, invoking sbt with + or sbt-release with "release cross" only serves to confuse things.
+// Always run release as `sbt clean release`!
 val checkRunCorrectly = ReleaseStep(action = st => {
   val allcommands = (st.history.executed ++ st.currentCommand ++ st.remainingCommands).map(_.commandLine)
   val crossCommands = allcommands.exists(_ contains "+")
@@ -51,6 +54,12 @@ val sonatypeReleaseSettings = {
       email = "digitalcms.dev@theguardian.com",
       url = url("https://github.com/orgs/guardian/teams/digital-cms")
     )),
+    // sbt and sbt-release implement cross-building support differently. sbt does it better
+    // (it supports each subproject having different crossScalaVersions), so disable sbt-release's
+    // implementation, and do the publish step with a `+`,
+    // ie. (`releaseStepCommandAndRemaining("+publishSigned")`)
+    // See https://www.scala-sbt.org/1.x/docs/Cross-Build.html#Note+about+sbt-release
+    // Never run with "release cross" or "+release"! Odd things start happening
     releaseCrossBuild := false,
     releaseProcess := Seq[ReleaseStep](
       checkRunCorrectly,

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4.0"
+version in ThisBuild := "1.4.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.4.0-SNAPSHOT"
+version in ThisBuild := "1.4.0"


### PR DESCRIPTION
@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->

I made a couple of mistakes in the previous PR - to correctly get sbt-release to release a multiproject with differing cross scala configurations, we need to set releaseCrossBuild off (confusing! but gives control over crossbuilding to sbt, instead of sbt-release, and sbt handles it better); and include the sonatypeReleaseSettings on the _root_ project, _and_ sonatype won't publish without a homepage set.

Once all of that is done, the only and only correct way to run a release is `sbt clean release` (and NOT `sbt clean +release`, `sbt clean "release cross"` or any other invocation which refers to crossbuilding!)