### PR TITLE
exclude hmac-examples from snyk monitoring

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -14,6 +14,7 @@ jobs:
       ORG: guardian
       SKIP_NODE: false
       NODE_VERSION_FILE: ./pan-domain-node/.nvmrc
+      EXCLUDE: hmac-examples
       
       
     secrets:


### PR DESCRIPTION
@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->

same as what https://github.com/guardian/panda-hmac did - these dirs aren't actively kept up to date and aren't for production use, so are only red herrings