### PR TITLE
CVE-2023-33202: replace jdk1.5 bouncycastle with 1.8, then upgrade to receive CVE fix

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,7 +45,7 @@ object Dependencies {
   )
 
   val cryptoDependencies = Seq(
-    "org.bouncycastle" % "bcprov-jdk15on" % "1.69",
+    "org.bouncycastle" % "bcprov-jdk18on" % "1.77",
     "commons-codec" % "commons-codec" % "1.14"
   )
 


### PR DESCRIPTION
@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->

- [ ] tested on crosswordv2 in CODE