### PR TITLE
Retry when discovery document fetcher fails

### DIFF
--- a/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -73,7 +73,7 @@ trait AuthActions {
     */
   def authCallbackUrl: String
 
-  val OAuth = new OAuth(settings.oAuthSettings, system, authCallbackUrl)
+  val OAuth = new OAuth(settings.oAuthSettings, system, authCallbackUrl)(ec, wsClient)
 
   /**
     * Application name used for initialising Google API clients for directory group checking
@@ -119,9 +119,9 @@ trait AuthActions {
     * starts the authentication process for a user. By default this just sends the user off to the OAuth provider for auth
     * but if you want to show welcome page with a button on it then override.
     */
-  def sendForAuth[A](implicit request: RequestHeader, email: Option[String] = None) = {
+  def sendForAuth(implicit request: RequestHeader, email: Option[String] = None) = {
     val antiForgeryToken = OAuth.generateAntiForgeryToken()
-    OAuth.redirectToOAuthProvider(antiForgeryToken, email)(ec, request, wsClient) map { res =>
+    OAuth.redirectToOAuthProvider(antiForgeryToken, email)(ec) map { res =>
       val originUrl = request.uri
       res.withCookies(cookie(ANTI_FORGERY_KEY, antiForgeryToken), cookie(LOGIN_ORIGIN_KEY, originUrl))
     }


### PR DESCRIPTION
@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->

Motivated by seeing an example where DNS resolution failed for the discovery document, and that failure was held for the rest of the instance's lifetime. If when asking for the discovery document future, we see that the fetch has failed; replace the future with a fresh fetch.