### PR TITLE
CVE-2024-30172: upgrade bouncycastle to 1.78

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,7 +45,7 @@ object Dependencies {
   )
 
   val cryptoDependencies = Seq(
-    "org.bouncycastle" % "bcprov-jdk18on" % "1.77",
+    "org.bouncycastle" % "bcprov-jdk18on" % "1.78",
     "commons-codec" % "commons-codec" % "1.14"
   )
 


### PR DESCRIPTION
see <https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6612984>


@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->