### PR TITLE
Automated releases using gha-scala-library-release-workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
+    permissions: { contents: write, pull-requests: write }
+    secrets:
+      SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
+      PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}
+      GITHUB_APP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_GITHUB_APP_PRIVATE_KEY }}

--- a/build.sbt
+++ b/build.sbt
@@ -5,30 +5,12 @@ import sbtrelease._
 import ReleaseStateTransformations._
 import xerial.sbt.Sonatype._
 import play.sbt.PlayImport.PlayKeys._
+import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 val scala212 = "2.12.15"
 val scala213 = "2.13.8"
 
 ThisBuild / scalaVersion := scala213
-
-// See below - the release process itself is correctly configured to publish the cross-built
-// subprojects, invoking sbt with + or sbt-release with "release cross" only serves to confuse things.
-// Always run release as `sbt clean release`!
-val checkRunCorrectly = ReleaseStep(action = st => {
-  val allcommands = (st.history.executed ++ st.currentCommand ++ st.remainingCommands).map(_.commandLine)
-  val crossCommands = allcommands.exists(_ contains "+")
-  val releaseCommandWithArgs = allcommands.exists(cmd => cmd.contains("release") && cmd != "release")
-  
-  if (crossCommands) {
-    st.log.error("Don't run release commands with cross building! Try again with 'sbt clean release'.")
-    sys.exit(1)
-  } else if (releaseCommandWithArgs) {
-    st.log.error("Don't run the release command with arguments! Try again with 'sbt clean release'.")
-    sys.exit(1)
-  }
-
-  st
-})
 
 val commonSettings =
   Seq(
@@ -46,19 +28,7 @@ val commonSettings =
 
 val sonatypeReleaseSettings = {
   sonatypeSettings ++ Seq(
-    publishTo := sonatypePublishToBundle.value,
-    licenses := Seq("Apache V2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html")),
-    scmInfo := Some(ScmInfo(
-      url("https://github.com/guardian/pan-domain-authentication"),
-      "scm:git:git@github.com:guardian/pan-domain-authentication.git"
-    )),
-    homepage := Some(url("https://github.com/guardian/pan-domain-authentication")),
-    developers := List(Developer(
-      id = "GuardianEdTools",
-      name = "Guardian Editorial Tools",
-      email = "digitalcms.dev@theguardian.com",
-      url = url("https://github.com/orgs/guardian/teams/digital-cms")
-    )),
+    licenses := Seq(License.Apache2),
     // sbt and sbt-release implement cross-building support differently. sbt does it better
     // (it supports each subproject having different crossScalaVersions), so disable sbt-release's
     // implementation, and do the publish step with a `+`,
@@ -66,8 +36,8 @@ val sonatypeReleaseSettings = {
     // See https://www.scala-sbt.org/1.x/docs/Cross-Build.html#Note+about+sbt-release
     // Never run with "release cross" or "+release"! Odd things start happening
     releaseCrossBuild := false,
+    releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
     releaseProcess := Seq[ReleaseStep](
-      checkRunCorrectly,
       checkSnapshotDependencies,
       inquireVersions,
       runClean,
@@ -75,12 +45,8 @@ val sonatypeReleaseSettings = {
       setReleaseVersion,
       commitReleaseVersion,
       tagRelease,
-      // For non cross-build projects, use releaseStepCommand("publishSigned")
-      releaseStepCommandAndRemaining("+publishSigned"),
-      releaseStepCommand("sonatypeBundleRelease"),
       setNextVersion,
-      commitNextVersion,
-      pushChanges
+      commitNextVersion
     )
   )
 }
@@ -94,7 +60,6 @@ lazy val panDomainAuthVerification = project("pan-domain-auth-verification")
       ++ testDependencies
       ++ loggingDependencies
       ++ scalaCollectionCompatDependencies,
-    publishArtifact := true
   )
 
 
@@ -108,7 +73,6 @@ lazy val panDomainAuthCore = project("pan-domain-auth-core")
       ++ cryptoDependencies
       ++ testDependencies
       ++ scalaCollectionCompatDependencies,
-    publishArtifact := true
   )
 
 lazy val panDomainAuthPlay_2_8 = project("pan-domain-auth-play_2-8")
@@ -118,7 +82,6 @@ lazy val panDomainAuthPlay_2_8 = project("pan-domain-auth-play_2-8")
     libraryDependencies
       ++= playLibs_2_8
       ++ scalaCollectionCompatDependencies,
-    publishArtifact := true
   ).dependsOn(panDomainAuthCore)
 
 lazy val panDomainAuthPlay_2_9 = project("pan-domain-auth-play_2-9")
@@ -129,7 +92,6 @@ lazy val panDomainAuthPlay_2_9 = project("pan-domain-auth-play_2-9")
     libraryDependencies
       ++= playLibs_2_9
       ++ scalaCollectionCompatDependencies,
-    publishArtifact := true
   ).dependsOn(panDomainAuthCore)
 
 lazy val panDomainAuthPlay_3_0 = project("pan-domain-auth-play_3-0")
@@ -140,7 +102,6 @@ lazy val panDomainAuthPlay_3_0 = project("pan-domain-auth-play_3-0")
     libraryDependencies
       ++= playLibs_3_0
       ++ scalaCollectionCompatDependencies,
-    publishArtifact := true
   ).dependsOn(panDomainAuthCore)
 
 lazy val panDomainAuthHmac_2_8 = project("panda-hmac-play_2-8")
@@ -148,23 +109,22 @@ lazy val panDomainAuthHmac_2_8 = project("panda-hmac-play_2-8")
   .settings(sonatypeReleaseSettings: _*)
   .settings(
     libraryDependencies ++= hmacLibs ++ playLibs_2_8 ++ testDependencies,
-    publishArtifact := true
   ).dependsOn(panDomainAuthPlay_2_8)
+
 lazy val panDomainAuthHmac_2_9 = project("panda-hmac-play_2-9")
   .settings(sourceDirectory := (ThisBuild / baseDirectory).value / "pan-domain-auth-hmac" / "src")
   .settings(sonatypeReleaseSettings: _*)
   .settings(
     crossScalaVersions := Seq(scala213),
     libraryDependencies ++= hmacLibs ++ playLibs_2_9 ++ testDependencies,
-    publishArtifact := true
   ).dependsOn(panDomainAuthPlay_2_9)
+
 lazy val panDomainAuthHmac_3_0 = project("panda-hmac-play_3-0")
   .settings(sourceDirectory := (ThisBuild / baseDirectory).value / "pan-domain-auth-hmac" / "src")
   .settings(sonatypeReleaseSettings: _*)
   .settings(
     crossScalaVersions := Seq(scala213),
     libraryDependencies ++= hmacLibs ++ playLibs_3_0 ++ testDependencies,
-    publishArtifact := true
   ).dependsOn(panDomainAuthPlay_3_0)
 
 lazy val exampleApp = project("pan-domain-auth-example")
@@ -173,7 +133,6 @@ lazy val exampleApp = project("pan-domain-auth-example")
   .dependsOn(panDomainAuthPlay_2_9)
   .settings(
     crossScalaVersions := Seq(scala213),
-    publishArtifact := false,
     publish / skip := true,
     playDefaultPort := 9500
   )
@@ -191,7 +150,6 @@ lazy val root = Project("pan-domain-auth-root", file(".")).aggregate(
 ).settings(sonatypeReleaseSettings)
  .settings(
   organization := "com.gu",
-  publishArtifact := false,
   publish / skip := true,
 )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,8 @@
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.0.3-SNAPSHOT"
+ThisBuild / version := "3.0.3-SNAPSHOT"


### PR DESCRIPTION
@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->

PR created by following steps in https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/configuration.md