### PR TITLE
update to latest scalas (2.12 and 2.13) to avoid binary incompatibility on 2.13.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ import xerial.sbt.Sonatype._
 import play.sbt.PlayImport.PlayKeys._
 import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
-val scala212 = "2.12.17"
-val scala213 = "2.13.9"
+val scala212 = "2.12.19"
+val scala213 = "2.13.13"
 
 ThisBuild / scalaVersion := scala213
 

--- a/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/service/oAuthModel.scala
+++ b/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/service/oAuthModel.scala
@@ -7,7 +7,7 @@ import org.apache.commons.codec.binary.Base64
 
 case class DiscoveryDocument(authorization_endpoint: String, token_endpoint: String, userinfo_endpoint: String)
 object DiscoveryDocument {
-  implicit val discoveryDocumentReads = Json.reads[DiscoveryDocument]
+  implicit val discoveryDocumentReads: Reads[DiscoveryDocument] = Json.reads[DiscoveryDocument]
   def fromJson(json: JsValue) = Json.fromJson[DiscoveryDocument](json).getOrElse(
     throw new IllegalArgumentException("Invalid discovery document")
   )
@@ -33,13 +33,13 @@ object Token {
 case class JwtClaims(iss: String, sub: String, azp: Option[String], email: Option[String], at_hash: String,
                      email_verified: Option[Boolean], aud: String, hd: Option[String], iat: Long, exp: Long)
 object JwtClaims {
-  implicit val claimsReads = Json.reads[JwtClaims]
+  implicit val claimsReads: Reads[JwtClaims] = Json.reads[JwtClaims]
 }
 
 case class UserInfo(sub: Option[String], name: String, given_name: String, family_name: String, profile: Option[String],
                     picture: Option[String], email: String, locale: Option[String], hd: Option[String])
 object UserInfo {
-  implicit val userInfoReads = Json.reads[UserInfo]
+  implicit val userInfoReads: Reads[UserInfo] = Json.reads[UserInfo]
 
   def fromJson(json:JsValue):UserInfo = {
     json.as[UserInfo]
@@ -54,9 +54,9 @@ case class JsonWebToken(jwt: String) {
 
 case class ErrorInfo(domain: String, reason: String, message: String)
 object ErrorInfo {
-  implicit val errorInfoReads = Json.reads[ErrorInfo]
+  implicit val errorInfoReads: Reads[ErrorInfo] = Json.reads[ErrorInfo]
 }
 case class Error(errors: Seq[ErrorInfo], code: Int, message: String)
 object Error {
-  implicit val errorReads = Json.reads[Error]
+  implicit val errorReads: Reads[Error] = Json.reads[Error]
 }


### PR DESCRIPTION
also apply recommended new compiler warning fixes from later version

see <https://github.com/scala/bug/issues/12650> for 2.13.9 binary incompatibility

<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->