### PR TITLE
expose an `authenticateRequest` function

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "3.0.4-SNAPSHOT"
+version in ThisBuild := "3.1.0-SNAPSHOT"


### PR DESCRIPTION
...on `AuthAction` & `APIAuthAction` which can be called with a `RequestHeader` allowing it to be used in play filters for example.

frontend uses play filters to ensure all of `preview` and `admin` endpoints are wrapped in auth... in https://github.com/guardian/frontend/pull/27012 we replace plain Google auth with pan-domain-authentication, but filters only deal in `RequestHeader` (understandably) but it would be useful to be able to reuse all of the authentication and redirect logic in the `AuthAction`, fortunately this was relatively straigh-forward (and is solving the problem when published locally).