### PR TITLE
Remove unused `com.gu.pandomainauth.Secret` class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+.bsp/
 
 # Scala-IDE specific
 .scala_dependencies

--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/PanDomainAuthSettings.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/model/PanDomainAuthSettings.scala
@@ -1,6 +1,6 @@
 package com.gu.pandomainauth.model
 
-import com.gu.pandomainauth.{PrivateKey, PublicKey, Secret}
+import com.gu.pandomainauth.{PrivateKey, PublicKey}
 
 case class PanDomainAuthSettings(
   publicKey: PublicKey,

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/package.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/package.scala
@@ -3,5 +3,4 @@ package com.gu
 package object pandomainauth {
   case class PublicKey(key: String) extends AnyVal
   case class PrivateKey(key: String) extends AnyVal
-  case class Secret(secret: String) extends AnyVal
 }


### PR DESCRIPTION
The `com.gu.pandomainauth.Secret` class, used for legacy symmetric encryption, was introduced with PR https://github.com/guardian/pan-domain-authentication/pull/30 back in June 2016, but was made [superfluous](https://github.com/guardian/pan-domain-authentication/pull/55/files#r1609823748) by PR https://github.com/guardian/pan-domain-authentication/pull/55 in April 2019.

We can safely remove it!
