### PR TITLE
Use token auth for Sonatype

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,6 @@ jobs:
     uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
     permissions: { contents: write, pull-requests: write }
     secrets:
-      SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
+      SONATYPE_TOKEN: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN }}
       PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}
       GITHUB_APP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_GITHUB_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Use token auth for Sonatype - see https://github.com/guardian/gha-scala-library-release-workflow/pull/23