### PR TITLE
Update docs to link to Emergency Panda key-rotation Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ publicKey=example_key
 
 ### Generating Keys
 
+**Guardian Devs**: See the [Emergency Panda key-rotation Guide](https://docs.google.com/document/d/1haVnQ9D8zNYUU-fOfkudPC1WpPGrlelLygd8V7xb3eQ/edit?usp=sharing).
+
 You can generate an rsa key pair as follows:
 
     openssl genrsa -out private_key.pem 4096


### PR DESCRIPTION
@andrew-nowak & I did a walkthrough in the CODE environment of the process necessary to do an Emergency rotation of the Panda cookie-signing key, and prepared a [full guide to the steps](https://docs.google.com/document/d/1haVnQ9D8zNYUU-fOfkudPC1WpPGrlelLygd8V7xb3eQ/edit?usp=sharing) (incidentally, I've placed this doc into the P&E shared drive to ensure it remains accessible).

This PR just links to that Google document!