### PR TITLE
Remove manual override for google-oauth-client

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,12 +36,6 @@ object Dependencies {
     "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev20230124-2.0.0",
     "com.google.auth" % "google-auth-library-credentials" % "1.16.0",
     "com.google.auth" % "google-auth-library-oauth2-http" % "1.16.0",
-    /*
-     * Normally transitive from the above, pull up manually to fix:
-        - https://app.snyk.io/vuln/SNYK-JAVA-COMGOOGLEOAUTHCLIENT-575276
-        - https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEOAUTHCLIENT-2807808
-     */
-    "com.google.oauth-client" % "google-oauth-client" % "1.33.3"
   )
 
   val cryptoDependencies = Seq(


### PR DESCRIPTION
The direct google dependencies of this project now include a version higher than the manually overridden one, which avoids the vulnerability the override was added to address.

## Before 

```
❯ sbt dependencyTree | grep "google-oauth-client"
[info]   |   +-com.google.oauth-client:google-oauth-client:1.34.1
[info]   +-com.google.oauth-client:google-oauth-client:1.34.1
[info]   | |   +-com.google.oauth-client:google-oauth-client:1.34.1
[info]   | +-com.google.oauth-client:google-oauth-client:1.33.3 (evicted by: 1.34.1)
[info]   | +-com.google.oauth-client:google-oauth-client:1.34.1
[info]   | |   +-com.google.oauth-client:google-oauth-client:1.34.1
[info]   | +-com.google.oauth-client:google-oauth-client:1.33.3 (evicted by: 1.34.1)
[info]   | +-com.google.oauth-client:google-oauth-client:1.34.1
[info]   | |   +-com.google.oauth-client:google-oauth-client:1.34.1
[info]   | +-com.google.oauth-client:google-oauth-client:1.33.3 (evicted by: 1.34.1)
[info]   | +-com.google.oauth-client:google-oauth-client:1.34.1
[info]     | |   +-com.google.oauth-client:google-oauth-client:1.34.1
[info]     | +-com.google.oauth-client:google-oauth-client:1.33.3 (evicted by: 1.34.1)
[info]     | +-com.google.oauth-client:google-oauth-client:1.34.1
[info]   | | |   +-com.google.oauth-client:google-oauth-client:1.34.1
[info]   | | +-com.google.oauth-client:google-oauth-client:1.33.3 (evicted by: 1.34.1)
[info]   | | +-com.google.oauth-client:google-oauth-client:1.34.1
[info]     | |   +-com.google.oauth-client:google-oauth-client:1.34.1
[info]     | +-com.google.oauth-client:google-oauth-client:1.33.3 (evicted by: 1.34.1)
[info]     | +-com.google.oauth-client:google-oauth-client:1.34.1
[info]     | |   +-com.google.oauth-client:google-oauth-client:1.34.1
[info]     | +-com.google.oauth-client:google-oauth-client:1.33.3 (evicted by: 1.34.1)
[info]     | +-com.google.oauth-client:google-oauth-client:1.34.1
```

## After

```
❯ sbt dependencyTree | grep "google-oauth-client"
[info]   |   +-com.google.oauth-client:google-oauth-client:1.34.1
[info]   | |   +-com.google.oauth-client:google-oauth-client:1.34.1
[info]   | |   +-com.google.oauth-client:google-oauth-client:1.34.1
[info]   | |   +-com.google.oauth-client:google-oauth-client:1.34.1
[info]     | |   +-com.google.oauth-client:google-oauth-client:1.34.1
[info]     | |   +-com.google.oauth-client:google-oauth-client:1.34.1
[info]   | | |   +-com.google.oauth-client:google-oauth-client:1.34.1
[info]     | |   +-com.google.oauth-client:google-oauth-client:1.34.1
```

@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->