### PR TITLE
Refactor Settings loading-&-parsing

### DIFF
--- a/pan-domain-auth-example/app/VerifyExample.scala
+++ b/pan-domain-auth-example/app/VerifyExample.scala
@@ -1,8 +1,9 @@
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.gu.pandomainauth.S3BucketLoader.forAwsSdkV1
 import com.gu.pandomainauth.model.{Authenticated, AuthenticatedUser, GracePeriod}
-import com.gu.pandomainauth.{PanDomain, PublicSettings}
+import com.gu.pandomainauth.{PanDomain, PublicSettings, Settings}
 
 object VerifyExample {
   // Change this to point to the S3 bucket and key for the settings file
@@ -14,16 +15,13 @@ object VerifyExample {
   val credentials = DefaultAWSCredentialsProviderChain.getInstance()
   val s3Client = AmazonS3ClientBuilder.standard().withRegion(region).withCredentials(credentials).build()
 
-  val publicSettings = new PublicSettings(settingsFileKey, bucketName, s3Client)
+  val loader = new Settings.Loader(forAwsSdkV1(s3Client, bucketName), settingsFileKey)
+  val publicSettings = PublicSettings(loader)
 
   // Call the start method when your application starts up to ensure the settings are kept up to date
   publicSettings.start()
 
-  // You can integrate with your own scheduler by calling refresh() which will synchronously update the settings
-  publicSettings.refresh()
-
-  // `publicKey` will return None if a value has not been successfully obtained
-  val publicKey = publicSettings.publicKey.get
+  val publicKey = publicSettings.publicKey
 
   // The name of this particular application
   val system = "test"

--- a/pan-domain-auth-example/app/di.scala
+++ b/pan-domain-auth-example/app/di.scala
@@ -3,6 +3,7 @@ import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsPro
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.pandomainauth.S3BucketLoader.forAwsSdkV1
 import controllers.AdminController
 import play.api.ApplicationLoader.Context
 import play.api.libs.ws.ahc.AhcWSComponents
@@ -34,12 +35,10 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
 
   val s3Client = AmazonS3ClientBuilder.standard().withRegion(region).withCredentials(credentials).build()
 
-  val panDomainSettings = new PanDomainAuthSettingsRefresher(
+  val panDomainSettings = PanDomainAuthSettingsRefresher(
     domain = "local.dev-gutools.co.uk",
     system = "example",
-    bucketName = bucketName,
-    settingsFileKey = "local.dev-gutools.co.uk.settings",
-    s3Client = s3Client
+    s3BucketLoader = forAwsSdkV1(s3Client, bucketName)
   )
 
   val controller = new AdminController(controllerComponents, configuration, wsClient, panDomainSettings)

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PublicSettings.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PublicSettings.scala
@@ -1,51 +1,35 @@
 package com.gu.pandomainauth
 
-import java.util.concurrent.atomic.AtomicReference
-import java.util.concurrent.{Executors, ScheduledExecutorService, TimeUnit}
 import com.amazonaws.services.s3.AmazonS3
-import com.gu.pandomainauth.PublicSettings.validateAndParseKeyText
-import com.gu.pandomainauth.service.Crypto
-import org.slf4j.LoggerFactory
+import com.gu.pandomainauth.Settings.Loader
+import com.gu.pandomainauth.SettingsFailure.SettingsResult
+import com.gu.pandomainauth.service.CryptoConf
 
 import java.security.PublicKey
-import java.util.regex.Pattern
-import scala.concurrent.ExecutionContext
+import java.util.concurrent.Executors.newScheduledThreadPool
+import java.util.concurrent.{Executors, ScheduledExecutorService}
 import scala.concurrent.duration._
 
 /**
  * Class that contains the static public settings and includes mechanism for fetching the public key. Once you have an
  * instance, call the `start()` method to load the public data.
-  *
-  * @param settingsFileKey the settings file for the domain in the S3 bucket (eg local.dev.gutools.co.uk.public.settings)
-  * @param bucketName      the name of the S3 bucket (eg pan-domain-auth-settings)
-  * @param s3Client        the AWS S3 client that will be used to download the settings from the bucket
-  * @param scheduler       optional scheduler that will be used to run the code that updates the bucket
  */
-class PublicSettings(settingsFileKey: String, bucketName: String, s3Client: AmazonS3,
-                     scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(1)) {
+class PublicSettings(loader: Settings.Loader, scheduler: ScheduledExecutorService) {
 
-  private val agent = new AtomicReference[Option[PublicKey]](None)
+  def this(settingsFileKey: String, bucketName: String, s3Client: AmazonS3,
+    scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(1)) = this(
+    new Settings.Loader(S3BucketLoader.forAwsSdkV1(s3Client, bucketName), settingsFileKey), scheduler
+  )
 
-  private val logger = LoggerFactory.getLogger(this.getClass)
-  implicit private val executionContext: ExecutionContext = ExecutionContext.fromExecutor(scheduler)
+  private val settingsRefresher = new Settings.Refresher[PublicKey](
+    loader,
+    CryptoConf.SettingsReader(_).activePublicKey,
+    scheduler
+  )
 
-  def start(interval: FiniteDuration = 60.seconds): Unit = {
-    scheduler.scheduleAtFixedRate(() => refresh(), 0, interval.toMillis, TimeUnit.MILLISECONDS)
-  }
+  def start(interval: FiniteDuration = 60.seconds): Unit = settingsRefresher.start(interval.toMinutes.toInt)
 
-  def refresh(): Unit = {
-    PublicSettings.getPublicKey(settingsFileKey, bucketName, s3Client) match {
-      case Right(publicKey) =>
-        agent.set(Some(publicKey))
-        logger.debug("Successfully updated pan-domain public settings")
-
-      case Left(err) =>
-        logger.error("Failed to update pan-domain public settings")
-        Settings.logError(err, logger)
-    }
-  }
-
-  def publicKey: Option[PublicKey] = agent.get()
+  def publicKey: PublicKey = settingsRefresher.get()
 }
 
 /**
@@ -53,24 +37,14 @@ class PublicSettings(settingsFileKey: String, bucketName: String, s3Client: Amaz
  * public data.
  */
 object PublicSettings {
-  import Settings._
+
+  def apply(loader: Settings.Loader): PublicSettings = new PublicSettings(loader, newScheduledThreadPool(1))
 
   /**
    * Fetches the public key from the public S3 bucket
    *
    * @param domain the domain to fetch the public key for
-   * @param client implicit dispatch.Http to use for fetching the key
-   * @param ec     implicit execution context to use for fetching the key
    */
-  def getPublicKey(settingsFileKey: String, bucketName: String, s3Client: AmazonS3): Either[SettingsFailure, PublicKey] = {
-    fetchSettings(settingsFileKey, bucketName, s3Client) flatMap extractSettings flatMap extractPublicKey
-  }
-
-  private[pandomainauth] def extractPublicKey(settings: Map[String, String]): Either[SettingsFailure, PublicKey] =
-    settings.get("publicKey").toRight(PublicKeyNotFoundFailure).flatMap(validateAndParseKeyText)
-
-  private val KeyPattern: Pattern = "[a-zA-Z0-9+/\n]+={0,3}".r.pattern
-
-  private[pandomainauth] def validateAndParseKeyText(pubKeyText: String): Either[SettingsFailure, PublicKey] =
-    Either.cond(KeyPattern.matcher(pubKeyText).matches, Crypto.publicKeyFor(pubKeyText), PublicKeyFormatFailure)
+  def getPublicKey(loader: Loader): SettingsResult[PublicKey] =
+    loader.loadAndParseSettingsMap().flatMap(CryptoConf.SettingsReader(_).activePublicKey)
 }

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/S3BucketLoader.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/S3BucketLoader.scala
@@ -1,0 +1,25 @@
+package com.gu.pandomainauth
+
+import com.amazonaws.services.s3.AmazonS3
+
+import java.io.InputStream
+
+/**
+ * This trait provides a way to download a file from an S3 bucket, in a way that's agnostic of which
+ * AWS SDK (v1 or v2) is being used. An instance of S3BucketLoader is *specific* to a particular S3 bucket.
+ */
+trait S3BucketLoader {
+  /**
+   * @param key the key of the file in the S3 bucket, not including the bucket name or a starting "/"
+   */
+  def inputStreamFetching(key: String): InputStream
+}
+
+object S3BucketLoader {
+  /**
+   * A convenience method to create an S3BucketLoader using AWS SDK v1, the version used by most of our existing code.
+   * However, codebases that want to use AWS SDK v2 are able to provide their own implementation of S3BucketLoader.
+   */
+  def forAwsSdkV1(s3Client: AmazonS3, bucketName: String): S3BucketLoader =
+    s3Client.getObject(bucketName, _).getObjectContent
+}

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/Settings.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/Settings.scala
@@ -1,66 +1,105 @@
 package com.gu.pandomainauth
 
+import com.amazonaws.util.IOUtils
+import com.gu.pandomainauth.SettingsFailure.SettingsResult
+import org.slf4j.{Logger, LoggerFactory}
+
 import java.io.ByteArrayInputStream
 import java.util.Properties
-
-import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.util.IOUtils
-import org.slf4j.Logger
-
-import scala.util.control.NonFatal
+import java.util.concurrent.TimeUnit.MINUTES
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.{Executors, ScheduledExecutorService}
 import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
 
-sealed trait SettingsFailure
-case class SettingsDownloadFailure(cause: Throwable) extends SettingsFailure
-case class SettingsParseFailure(cause: Throwable) extends SettingsFailure
-case object PublicKeyFormatFailure extends SettingsFailure
-case object PublicKeyNotFoundFailure extends SettingsFailure
+sealed trait SettingsFailure {
+  val description: String
+
+  def logError(logger: Logger): Unit = logger.error(description)
+
+  def asThrowable(): Throwable = new IllegalStateException(description)
+}
+
+trait FailureWithCause extends SettingsFailure {
+  val cause: Throwable
+
+  override def logError(logger: Logger): Unit = logger.error(description, cause)
+
+  override def asThrowable(): Throwable = new IllegalStateException(description, cause)
+}
+
+case class SettingsDownloadFailure(cause: Throwable) extends FailureWithCause {
+  override val description: String = "Unable to download public key"
+}
+
+case class MissingSetting(name: String) extends SettingsFailure {
+  override val description: String = s"Key '$name' not found in settings file"
+}
+
+case class SettingsParseFailure(cause: Throwable) extends FailureWithCause {
+  override val description: String = "Unable to parse public key"
+}
+
+case object PublicKeyFormatFailure extends SettingsFailure {
+  override val description: String = "Public key does not match expected format"
+}
+
+case object InvalidBase64 extends SettingsFailure {
+  override val description: String = "Settings file value for cryptographic key is not valid base64"
+}
+
+object SettingsFailure {
+  type SettingsResult[A] = Either[SettingsFailure, A]
+}
 
 object Settings {
-  // internal functions for fetching and parsing the responses
-  def fetchSettings(settingsFileKey: String, bucketName: String, s3Client: AmazonS3): Either[SettingsFailure, String] = try {
-    val response = s3Client.getObject(bucketName, settingsFileKey)
-    Right(IOUtils.toString(response.getObjectContent))
-  } catch {
-    case NonFatal(e) =>
-      Left(SettingsDownloadFailure(e))
+  /**
+   * @param settingsFileKey the name of the file that contains the private settings for the given domain
+   */
+  class Loader(s3BucketLoader: S3BucketLoader, settingsFileKey: String) {
+
+    def loadAndParseSettingsMap(): SettingsResult[Map[String, String]] = fetchSettings().flatMap(extractSettings)
+
+    private def fetchSettings(): SettingsResult[String] = try {
+      Right(IOUtils.toString(s3BucketLoader.inputStreamFetching(settingsFileKey)))
+    } catch { case NonFatal(e) => Left(SettingsDownloadFailure(e)) }
   }
 
-  private[pandomainauth] def extractSettings(settingsBody: String): Either[SettingsFailure, Map[String, String]] = try {
+  private[pandomainauth] def extractSettings(settingsBody: String): SettingsResult[Map[String, String]] = try {
     val props = new Properties()
     props.load(new ByteArrayInputStream(settingsBody.getBytes("UTF-8")))
-
     Right(props.asScala.toMap)
   } catch {
     case NonFatal(e) =>
       Left(SettingsParseFailure(e))
   }
 
-  def logError(failure: SettingsFailure, logger: Logger) = failure match {
-    case SettingsDownloadFailure(cause) =>
-      logger.error("Unable to download public key", cause)
+  class Refresher[A](
+    loader: Settings.Loader,
+    settingsParser: Map[String, String] => SettingsResult[A],
+    scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(1)
+  ) {
+    // This is deliberately designed to throw an exception during construction if we cannot immediately read the settings
+    private val store: AtomicReference[A] = new AtomicReference(
+      loadAndParseSettings().fold(fail => throw fail.asThrowable(), identity)
+    )
 
-    case SettingsParseFailure(cause) =>
-      logger.error("Unable to parse public key", cause)
+    private val logger = LoggerFactory.getLogger(getClass)
 
-    case PublicKeyFormatFailure =>
-      logger.error("Public key does not match expected format")
+    def start(interval: Int): Unit = scheduler.scheduleAtFixedRate(() => refresh(), 0, interval, MINUTES)
 
-    case PublicKeyNotFoundFailure =>
-      logger.error("Public key not found in settings file")
-  }
+    def loadAndParseSettings(): SettingsResult[A] =
+      loader.loadAndParseSettingsMap().flatMap(settingsParser)
 
-  def errorToThrowable(failure: SettingsFailure): Throwable = failure match {
-    case SettingsDownloadFailure(cause) =>
-      new IllegalStateException("Unable to download public key", cause)
+    private def refresh(): Unit = loadAndParseSettings() match {
+      case Right(newSettings) =>
+        // logger.debug(s"Updated pan-domain settings for $domain")
+        val oldSettings = store.getAndSet(newSettings)
+      case Left(err) =>
+        logger.error("Failed to update pan-domain settings for $domain")
+        err.logError(logger)
+    }
 
-    case SettingsParseFailure(cause) =>
-      new IllegalStateException("Unable to parse public key", cause)
-
-    case PublicKeyFormatFailure =>
-      new IllegalStateException("Public key does not match expected format")
-
-    case PublicKeyNotFoundFailure =>
-      new IllegalStateException("Public key not found in settings file")
+    def get(): A = store.get()
   }
 }

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/Settings.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/Settings.scala
@@ -93,8 +93,8 @@ object Settings {
 
     private def refresh(): Unit = loadAndParseSettings() match {
       case Right(newSettings) =>
-        // logger.debug(s"Updated pan-domain settings for $domain")
         val oldSettings = store.getAndSet(newSettings)
+        if (oldSettings != newSettings) logger.info("Updated pan-domain settings")
       case Left(err) =>
         logger.error("Failed to update pan-domain settings for $domain")
         err.logError(logger)

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/Crypto.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/Crypto.scala
@@ -1,9 +1,7 @@
 package com.gu.pandomainauth.service
 
-import org.apache.commons.codec.binary.Base64._
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 
-import java.security.spec.{PKCS8EncodedKeySpec, X509EncodedKeySpec}
 import java.security._
 
 
@@ -37,12 +35,4 @@ object Crypto {
     rsa.update(data)
     rsa.verify(signature)
   }
-
-  def publicKeyFor(base64EncodedKey: String): PublicKey =
-    keyFactory.generatePublic(new X509EncodedKeySpec(decodeBase64(base64EncodedKey)))
-  def privateKeyFor(base64EncodedKey: String): PrivateKey =
-    keyFactory.generatePrivate(new PKCS8EncodedKeySpec(decodeBase64(base64EncodedKey)))
-
-  def keyPairFrom(settingMap: Map[String,String]): KeyPair =
-    new KeyPair(publicKeyFor(settingMap("publicKey")), privateKeyFor(settingMap("privateKey")))
 }

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/CryptoConf.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/CryptoConf.scala
@@ -1,0 +1,44 @@
+package com.gu.pandomainauth.service
+
+import com.gu.pandomainauth.SettingsFailure.SettingsResult
+import com.gu.pandomainauth.service.Crypto.keyFactory
+import com.gu.pandomainauth.service.CryptoConf.SettingsReader.{privateKeyFor, publicKeyFor}
+import com.gu.pandomainauth.{InvalidBase64, MissingSetting, PublicKeyFormatFailure}
+import org.apache.commons.codec.binary.Base64.{decodeBase64, isBase64}
+
+import java.security.spec.{InvalidKeySpecException, PKCS8EncodedKeySpec, X509EncodedKeySpec}
+import java.security.{PrivateKey, PublicKey}
+import scala.util.Try
+
+
+
+object CryptoConf {
+  case class SettingsReader(settingMap: Map[String,String]) {
+    def setting(key: String): SettingsResult[String] = settingMap.get(key).toRight(MissingSetting(key))
+
+    val activePublicKey: SettingsResult[PublicKey] = setting("publicKey").flatMap(publicKeyFor)
+
+    def activeKeyPair: SettingsResult[KeyPair] = for {
+      publicKey <- activePublicKey
+      privateKey <- setting("privateKey").flatMap(privateKeyFor)
+    } yield KeyPair(publicKey, privateKey)
+  }
+
+  object SettingsReader {
+    def publicKeyFor(data: Array[Byte]) = keyFactory.generatePublic(new X509EncodedKeySpec(data))
+    def privateKeyFor(data: Array[Byte]) = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(data))
+
+    def bytesFromBase64(base64Encoded: String): SettingsResult[Array[Byte]] =
+      Either.cond(isBase64(base64Encoded), decodeBase64(base64Encoded), InvalidBase64)
+
+    private def keyFor[A](keyConstructor: Array[Byte] => A, base64EncodedKey: String): SettingsResult[A] = for {
+      bytes <- bytesFromBase64(base64EncodedKey)
+      key <- Try(keyConstructor(bytes)).map(Right(_)).recover {
+        case _: InvalidKeySpecException => Left(PublicKeyFormatFailure)
+      }.get
+    } yield key
+
+    def publicKeyFor(base64EncodedKey: String): SettingsResult[PublicKey] = keyFor(publicKeyFor, base64EncodedKey)
+    def privateKeyFor(base64EncodedKey: String): SettingsResult[PrivateKey] = keyFor(privateKeyFor, base64EncodedKey)
+  }
+}

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/CryptoConf.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/CryptoConf.scala
@@ -6,11 +6,9 @@ import com.gu.pandomainauth.service.CryptoConf.SettingsReader.{privateKeyFor, pu
 import com.gu.pandomainauth.{InvalidBase64, MissingSetting, PublicKeyFormatFailure}
 import org.apache.commons.codec.binary.Base64.{decodeBase64, isBase64}
 
-import java.security.spec.{InvalidKeySpecException, PKCS8EncodedKeySpec, X509EncodedKeySpec}
-import java.security.{PrivateKey, PublicKey}
+import java.security.spec.{InvalidKeySpecException, KeySpec, PKCS8EncodedKeySpec, X509EncodedKeySpec}
+import java.security.{KeyFactory, PrivateKey, PublicKey}
 import scala.util.Try
-
-
 
 object CryptoConf {
   case class SettingsReader(settingMap: Map[String,String]) {
@@ -25,20 +23,23 @@ object CryptoConf {
   }
 
   object SettingsReader {
-    def publicKeyFor(data: Array[Byte]) = keyFactory.generatePublic(new X509EncodedKeySpec(data))
-    def privateKeyFor(data: Array[Byte]) = keyFactory.generatePrivate(new PKCS8EncodedKeySpec(data))
-
-    def bytesFromBase64(base64Encoded: String): SettingsResult[Array[Byte]] =
+    private def bytesFromBase64(base64Encoded: String): SettingsResult[Array[Byte]] =
       Either.cond(isBase64(base64Encoded), decodeBase64(base64Encoded), InvalidBase64)
 
-    private def keyFor[A](keyConstructor: Array[Byte] => A, base64EncodedKey: String): SettingsResult[A] = for {
+    private def keyFor[A](
+      base64EncodedKey: String,
+      keySpecFor: Array[Byte] => KeySpec,
+      keyForSpec: KeyFactory => KeySpec => A
+    ): SettingsResult[A] = for {
       bytes <- bytesFromBase64(base64EncodedKey)
-      key <- Try(keyConstructor(bytes)).map(Right(_)).recover {
+      key <- Try(keyForSpec(keyFactory)(keySpecFor(bytes))).map(Right(_)).recover {
         case _: InvalidKeySpecException => Left(PublicKeyFormatFailure)
       }.get
     } yield key
 
-    def publicKeyFor(base64EncodedKey: String): SettingsResult[PublicKey] = keyFor(publicKeyFor, base64EncodedKey)
-    def privateKeyFor(base64EncodedKey: String): SettingsResult[PrivateKey] = keyFor(privateKeyFor, base64EncodedKey)
+    def publicKeyFor(base64Key: String): SettingsResult[PublicKey] =
+      keyFor(base64Key, new X509EncodedKeySpec(_), _.generatePublic)
+    def privateKeyFor(base64Key: String): SettingsResult[PrivateKey] =
+      keyFor(base64Key, new PKCS8EncodedKeySpec(_), _.generatePrivate)
   }
 }

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/KeyPair.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/KeyPair.scala
@@ -1,0 +1,9 @@
+package com.gu.pandomainauth.service
+
+import java.security.{PrivateKey, PublicKey}
+
+/**
+ * This class mainly exists because java.security.KeyPair does not implement a useful `.equals()`` method,
+ * and we're going to want to be able to check whether two key-pairs are equal.
+ */
+case class KeyPair(publicKey: PublicKey, privateKey: PrivateKey)

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/CryptoConfTest.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/CryptoConfTest.scala
@@ -1,0 +1,34 @@
+package com.gu.pandomainauth
+
+import com.gu.pandomainauth.service.CryptoConf.SettingsReader
+import com.gu.pandomainauth.service.TestKeys.testPublicKey
+import org.scalatest.EitherValues
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+
+class CryptoConfTest extends AnyFreeSpec with Matchers with EitherValues {
+  "CryptoConf.SettingsReader" - {
+    "returns an error if the key looks invalid" in {
+      SettingsReader.publicKeyFor("not a valid key").left.value shouldEqual PublicKeyFormatFailure
+    }
+
+    "returns the key if it is valid" in {
+      SettingsReader.publicKeyFor(testPublicKey.base64Encoded) shouldEqual Right(testPublicKey.key)
+    }
+  }
+
+  "CryptoConf.SettingsReader activePublicKey" - {
+    "will get a public key from a valid settings map" in {
+      SettingsReader(Map("publicKey" -> testPublicKey.base64Encoded)).activePublicKey shouldEqual Right(testPublicKey.key)
+    }
+
+    "will reject a key that is not correctly formatted" in {
+      SettingsReader(Map("publicKey" -> "improperly formatted public key!!")).activePublicKey.left.value should be(InvalidBase64)
+    }
+
+    "will fail if the key is not present in the settings" in {
+      SettingsReader(Map("another key" -> "bar")).activePublicKey.left.value should be(MissingSetting("publicKey"))
+    }
+  }
+}

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/PublicSettingsTest.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/PublicSettingsTest.scala
@@ -1,38 +1,11 @@
 package com.gu.pandomainauth
 
-import com.gu.pandomainauth.service.TestKeys.testPublicKey
-import com.gu.pandomainauth.service.{Crypto, TestKeys}
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.EitherValues
+import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 
-class PublicSettingsTest extends AnyFreeSpec with Matchers with EitherValues with ScalaFutures {
-  "validateKey" - {
-    "returns an error if the key looks invalid" in {
-      val invalidKeyText = "not a valid key"
-      PublicSettings.validateAndParseKeyText(invalidKeyText).left.value shouldEqual PublicKeyFormatFailure
-    }
-
-    "returns the key if it is valid" in {
-      PublicSettings.validateAndParseKeyText(testPublicKey.base64Encoded) shouldEqual Right(testPublicKey.key)
-    }
-  }
-
-  "extractPublicKey" - {
-    "will get a public key from a valid settings map" in {
-      PublicSettings.extractPublicKey(Map("publicKey" -> testPublicKey.base64Encoded)) shouldEqual Right(testPublicKey.key)
-    }
-
-    "will reject a key that is not correctly formatted" in {
-      PublicSettings.extractPublicKey(Map("publicKey" -> "improperly formatted public key!!")).left.value should be(PublicKeyFormatFailure)
-    }
-
-    "will fail if the key is not present in the settings" in {
-      PublicSettings.extractPublicKey(Map("another key" -> "bar")).left.value should be(PublicKeyNotFoundFailure)
-    }
-  }
+class PublicSettingsTest extends AnyFreeSpec with Matchers with EitherValues {
 
   "extractSettings" - {
     "extracts properties from a valid body" in {

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/service/CryptoTest.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/service/CryptoTest.scala
@@ -1,6 +1,5 @@
 package com.gu.pandomainauth.service
 
-import com.gu.pandomainauth.service.Crypto.{privateKeyFor, publicKeyFor}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/service/TestKeys.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/service/TestKeys.scala
@@ -1,14 +1,15 @@
 package com.gu.pandomainauth.service
 
-import com.gu.pandomainauth.service.Crypto.{privateKeyFor, publicKeyFor}
+import com.gu.pandomainauth.SettingsFailure.SettingsResult
+import com.gu.pandomainauth.service.CryptoConf.SettingsReader.{privateKeyFor, publicKeyFor}
 
 import java.security.Key
 
 object TestKeys {
 
   case class Example[K <: Key](key: K, base64Encoded: String)
-  def example[K <: Key](f: String => K)(base64Encoded: String): Example[K] =
-    Example(f(base64Encoded), base64Encoded)
+  def example[K <: Key](f: String => SettingsResult[K])(base64Encoded: String): Example[K] =
+    Example(f(base64Encoded).toOption.get, base64Encoded)
 
   /**
    * A test public/private key-pair


### PR DESCRIPTION
This is a precursor to PR https://github.com/guardian/pan-domain-authentication/pull/150 (_"Support accepting multiple public keys"_). It helps with that PR because it consolidates the loading-&-parsing code for configuration settings (previously duplicated across the code for the `.settings` and `.settings.public` files), so that when we add support for configuring multiple public keys, we don't need to repeat the implementation.

* **New type alias `SettingsResult`**: rather than throw exceptions, communicate `SettingsFailure`s with return values of `SettingsResult`.
* **New class `Settings.Loader`**: takes responsibility for getting a settings `Map[String, String]` from S3, previously implemented in both `PanDomainAuthSettingsRefresher` and `PublicSettings`:
  https://github.com/guardian/pan-domain-authentication/blob/59c713202bfe9b301db4d70dda0480b73c89fba0/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/PanDomainAuthSettingsRefresher.scala#L43
  https://github.com/guardian/pan-domain-authentication/blob/59c713202bfe9b301db4d70dda0480b73c89fba0/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PublicSettings.scala#L66
* **New class `Settings.Refresher`**: polls S3 for settings updates, extracting common implementation from `PanDomainAuthSettingsRefresher` & `PublicSettings`.

### Testing

* https://github.com/guardian/atom-workshop/pull/361
* https://github.com/guardian/login.gutools/pull/81
* https://github.com/guardian/s3-upload/pull/58

### See also

* https://github.com/guardian/pan-domain-authentication/pull/150