### PR TITLE
Refactor Cookie generation-&-parsing

### DIFF
--- a/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -197,8 +197,8 @@ trait AuthActions {
     flushCookie(showUnauthedMessage("logged out"))
   }
 
-  def readAuthenticatedUser(request: RequestHeader): Option[AuthenticatedUser] = readCookie(request) map { cookie =>
-    CookieUtils.parseCookieData(cookie.cookie.value, settings.signingKeyPair.publicKey)
+  def readAuthenticatedUser(request: RequestHeader): Option[AuthenticatedUser] = readCookie(request) flatMap { cookie =>
+    CookieUtils.parseCookieData(cookie.cookie.value, settings.signingKeyPair.publicKey).toOption
   }
 
   def readCookie(request: RequestHeader): Option[PandomainCookie] = {

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PanDomain.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PanDomain.scala
@@ -12,13 +12,9 @@ object PanDomain {
    */
   def authStatus(cookieData: String, publicKey: PublicKey, validateUser: AuthenticatedUser => Boolean,
                  apiGracePeriod: Long, system: String, cacheValidation: Boolean, forceExpiry: Boolean): AuthenticationStatus = {
-    try {
-      val authedUser = CookieUtils.parseCookieData(cookieData, publicKey)
+    CookieUtils.parseCookieData(cookieData, publicKey).fold(InvalidCookie, { authedUser =>
       checkStatus(authedUser, validateUser, apiGracePeriod, system, cacheValidation, forceExpiry)
-    } catch {
-      case e: Exception =>
-        InvalidCookie(e)
-    }
+    })
   }
 
   private def checkStatus(authedUser: AuthenticatedUser, validateUser: AuthenticatedUser => Boolean,

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/model/AuthenticationStatus.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/model/AuthenticationStatus.scala
@@ -1,9 +1,11 @@
 package com.gu.pandomainauth.model
 
+import com.gu.pandomainauth.service.CookieUtils.CookieIntegrityFailure
+
 sealed trait AuthenticationStatus
 case class Expired(authedUser: AuthenticatedUser) extends AuthenticationStatus
 case class GracePeriod(authedUser: AuthenticatedUser) extends AuthenticationStatus
 case class Authenticated(authedUser: AuthenticatedUser) extends AuthenticationStatus
 case class NotAuthorized(authedUser: AuthenticatedUser) extends AuthenticationStatus
-case class InvalidCookie(exception: Exception) extends AuthenticationStatus
+case class InvalidCookie(e: CookieIntegrityFailure) extends AuthenticationStatus
 case object NotAuthenticated extends AuthenticationStatus

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/CookiePayload.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/CookiePayload.scala
@@ -1,0 +1,56 @@
+package com.gu.pandomainauth.service
+
+import com.gu.pandomainauth.service.CookiePayload.encodeBase64
+import org.apache.commons.codec.binary.Base64
+import org.apache.commons.codec.binary.Base64.isBase64
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.security.{PrivateKey, PublicKey}
+import scala.util.matching.Regex
+
+/**
+ * A representation of the underlying binary data (both payload & signature) in a Panda cookie.
+ *
+ * If an instance has been parsed from a cookie's text value, the existence of the instance
+ * *does not* imply that the signature has been verified. It only means that the cookie text was
+ * correctly formatted (two Base64 strings separated by '.').
+ *
+ * `CookiePayload` is designed to be the optimal representation of cookie data for checking
+ * signature-validity against *multiple* possible accepted public keys. It's a bridge between
+ * these two contexts:
+ *
+ * * cookie text: the raw cookie value - two Base64-encoded strings (payload & signature), separated by '.'
+ * * payload text: in Panda, a string representation of `AuthenticatedUser`
+ *
+ * To make those transformations, you need either a public or private key:
+ *
+ * * payload text -> cookie text: uses a *private* key to generate the signature
+ * * cookie text -> payload text: uses a *public* key to verify the signature
+ */
+case class CookiePayload(payloadBytes: Array[Byte], sig: Array[Byte]) {
+  def payloadTextVerifiedSignedWith(publicKey: PublicKey): Option[String] =
+    if (Crypto.verifySignature(payloadBytes, sig, publicKey)) Some(new String(payloadBytes, UTF_8)) else None
+
+  lazy val asCookieText: String = s"${encodeBase64(payloadBytes)}.${encodeBase64(sig)}"
+}
+
+object CookiePayload {
+  private val CookieRegEx: Regex = "^([\\w\\W]*)\\.([\\w\\W]*)$".r
+
+  private def encodeBase64(data: Array[Byte]): String = new String(Base64.encodeBase64(data), UTF_8)
+  private def decodeBase64(text: String): Array[Byte] = Base64.decodeBase64(text.getBytes(UTF_8))
+
+  /**
+   * @return `None` if the cookie text is incorrectly formatted (ie not "abc.xyz", with a '.' separator)
+   */
+  def parse(cookieText: String): Option[CookiePayload] = cookieText match {
+    case CookieRegEx(data, sig) if isBase64(data) && isBase64(sig) =>
+      Some(CookiePayload(decodeBase64(data), decodeBase64(sig)))
+    case _ => None
+  }
+
+  def generateForPayloadText(payloadText: String, privateKey: PrivateKey): CookiePayload = {
+    val data = payloadText.getBytes(UTF_8)
+    CookiePayload(data, Crypto.signData(data, privateKey))
+  }
+}

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/CookieUtils.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/CookieUtils.scala
@@ -51,9 +51,7 @@ object CookieUtils {
 
   def generateCookieData(authUser: AuthenticatedUser, prvKey: PrivateKey): String =
     CookiePayload.generateForPayloadText(serializeAuthenticatedUser(authUser), prvKey).asCookieText
-
-  // We would quite like to know, if a user is using an old (but accepted) key, *who* that user is- or to put it another
-  // way, give me the authenticated user, and tell me which key they're using
+  
   def parseCookieData(cookieString: String, publicKey: PublicKey): CookieResult[AuthenticatedUser] = for {
     cookiePayload <- CookiePayload.parse(cookieString).toRight(MalformedCookieText)
     cookiePayloadText <- cookiePayload.payloadTextVerifiedSignedWith(publicKey).toRight(SignatureNotValid)

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/CookieUtils.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/CookieUtils.scala
@@ -4,6 +4,7 @@ import com.gu.pandomainauth.model.{AuthenticatedUser, User}
 import com.gu.pandomainauth.service.CookieUtils.CookieIntegrityFailure.{MalformedCookieText, MissingOrMalformedUserData, SignatureNotValid}
 
 import java.security.{PrivateKey, PublicKey}
+import scala.util.Try
 
 object CookieUtils {
   sealed trait CookieIntegrityFailure
@@ -38,8 +39,8 @@ object CookieUtils {
       email <- data.get("email")
       system <- data.get("system")
       authedIn <- data.get("authedIn")
-      expires <- data.get("expires").flatMap(_.toLongOption)
-      multiFactor <- data.get("multifactor").flatMap(_.toBooleanOption)
+      expires <- data.get("expires").flatMap(text => Try(text.toLong).toOption)
+      multiFactor <- data.get("multifactor").flatMap(text => Try(text.toBoolean).toOption)
     } yield AuthenticatedUser(
       user = User(firstName, lastName, email, data.get("avatarUrl")),
       authenticatingSystem = system,

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/service/CookiePayloadTest.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/service/CookiePayloadTest.scala
@@ -1,0 +1,37 @@
+package com.gu.pandomainauth.service
+
+import org.scalatest.OptionValues
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import TestKeys._
+
+class CookiePayloadTest extends AnyFreeSpec with Matchers with OptionValues {
+
+  "CookiePayload" - {
+    "round-trip from payload text to CookiePayload if matching public-private keys are used" in {
+      val payloadText = "Boom"
+      val payload = CookiePayload.generateForPayloadText(payloadText, testPrivateKey.key)
+      payload.payloadTextVerifiedSignedWith(testPublicKey.key).value shouldBe payloadText
+    }
+
+    "not return payload text if a rogue key was used" in {
+      val payload = CookiePayload.generateForPayloadText("Boom", testINCORRECTPrivateKey.key)
+      payload.payloadTextVerifiedSignedWith(testPublicKey.key) shouldBe None
+    }
+
+    "reject cookie text that does not contain a ." in {
+      CookiePayload.parse("AQIDBAUG") shouldBe None
+    }
+
+    "reject cookie text that does not contain valid BASE64 text" in {
+      CookiePayload.parse("AQ!D.BAUG") shouldBe None
+      CookiePayload.parse("AQID.BA!G") shouldBe None
+    }
+
+    "round-trip from correctly-formatted cookie-text to CookiePayload instance and back again" in {
+      val correctlyFormattedCookieText = "AQID.BAUG"
+      val cookiePayload = CookiePayload.parse(correctlyFormattedCookieText).value
+      cookiePayload.asCookieText shouldBe correctlyFormattedCookieText
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,7 +43,7 @@ object Dependencies {
     "commons-codec" % "commons-codec" % "1.14"
   )
 
-  val testDependencies = Seq("org.scalatest" %% "scalatest" % "3.2.0" % "test")
+  val testDependencies = Seq("org.scalatest" %% "scalatest" % "3.2.19" % Test)
 
   val loggingDependencies = Seq("org.slf4j" % "slf4j-api" % "1.7.30")
 


### PR DESCRIPTION
This is a precursor to PR https://github.com/guardian/pan-domain-authentication/pull/150 (_"Support accepting multiple public keys"_). It helps with that PR because we're going to be changing the cookie processing code to validate against a _range_ of possible acceptable keys, and if a failure occurs in the reading of a cookie, we want to be clear about whether that happens to be due to the particular key we're attempting to validate against, or whether the cookie text itself is malformatted.

* **New class `CookiePayload`**: an optimal representation of cookie data for checking signature-validity against *multiple* public keys. The `CookiePayload` class represents the binary data caught after parsing-and-base64-decoding the cookie text value, ready for signature verification.
* **New type alias `CookieResult`**: rather than throw exceptions, communicate `CookieIntegrityFailure`s with return values of `CookieResult`.
