### PR TITLE
Fix creation of superfluous `PanDomainAuthSettingsRefresher` instances, make `panDomainSettings` a `val`

### DIFF
--- a/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -33,10 +33,10 @@ trait AuthActions {
     */
   def wsClient: WSClient
   def controllerComponents: ControllerComponents
-  def panDomainSettings: PanDomainAuthSettingsRefresher
+  val panDomainSettings: PanDomainAuthSettingsRefresher
 
-  private def system: String = panDomainSettings.system
-  private def domain: String = panDomainSettings.domain
+  private lazy val system: String = panDomainSettings.system
+  private lazy val domain: String = panDomainSettings.domain
   private def settings: PanDomainAuthSettings = panDomainSettings.settings
 
   private implicit val ec: ExecutionContext = controllerComponents.executionContext
@@ -82,14 +82,14 @@ trait AuthActions {
     */
   def authCallbackUrl: String
 
-  val OAuth = new OAuth(settings.oAuthSettings, system, authCallbackUrl)(ec, wsClient)
+  lazy val OAuth = new OAuth(settings.oAuthSettings, system, authCallbackUrl)(ec, wsClient)
 
   /**
     * Application name used for initialising Google API clients for directory group checking
     */
-  val applicationName: String = s"pan-domain-authentication-$system"
+  lazy val applicationName: String = s"pan-domain-authentication-$system"
 
-  val multifactorChecker: Option[Google2FAGroupChecker] = settings.google2FAGroupSettings.map {
+  lazy val multifactorChecker: Option[Google2FAGroupChecker] = settings.google2FAGroupSettings.map {
     new Google2FAGroupChecker(_, panDomainSettings.s3BucketLoader, applicationName)
   }
 


### PR DESCRIPTION
The field `panDomainSettings` in the `AuthActions` trait was defined as a `def`, which was problematic:

https://github.com/guardian/pan-domain-authentication/blob/65e1f65760a1df773589a2afb1fc2dd09944a89e/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala#L36

Having the field in trait as as a `def` means that implementors of `AuthActions` are able to make the mistake of _also_ defining their implementation of [that field as a `def`](https://github.com/guardian/atom-workshop/blob/2df73bdbb953401bc9480142fa04cee29f577a6b/app/AppComponents.scala#L33), meaning that every read of that field will create _another_ instance of the refresher, [as seen in Atom Workshop](https://github.com/guardian/atom-workshop/pull/361#issuecomment-2346317855). We can see that each EC2 instance has _lots_ of instances of `PanDomainAuthSettingsRefresher`, all logging about the config change:

![image](https://github.com/user-attachments/assets/05184fe4-9966-4826-a22f-9d5922e61c64)

Surprisingly, this seems to have been a problem since at least as far back as https://github.com/guardian/pan-domain-authentication/pull/41 in February 2018 (which was _also_ dealing with a problem where the refresher was instantiated too often!).

## Fix: make the trait field a `val` rather than a `def`

Changing the field type to `val` forces implementers to also use `val` for that field, effectively making it a **singleton**, which is what we want.

Changing the abstract field of a trait to be `val` does open up [another danger due the initialisation order of `val`s](https://docs.scala-lang.org/tutorials/FAQ/initialization-order.html) - the field could end up being evaluated as `null` if the trait immediately evaluates the field during construction.

...consequently, I've made all `val` declarations in the `AuthActions` trait (that evaluate `panDomainSettings` in some way) into `lazy val`s.

### Testing

[Deploying](https://riffraff.gutools.co.uk/deployment/view/05f3707f-20ce-4ffc-98c6-8e467079f001) https://github.com/guardian/atom-workshop/pull/366 at https://github.com/guardian/atom-workshop/commit/b6e8a2cd6ddffd11a775ae8e3770e2bd28a2f026 (using this PR at 61a193ca) to CODE, we see that when we change the Panda settings file in S3, there is, as desired, only **1** instance of `PanDomainAuthSettingsRefresher` per EC2 instance to [log about it](https://logs.gutools.co.uk/goto/89a5e740-7123-11ef-b481-afe258002fe1):

![image](https://github.com/user-attachments/assets/3d514f0b-d8af-445a-9213-d6de2a846101)

