### PR TITLE
Update CI GitHub Actions (actions/checkout, actions/setup-node, actions/setup-java)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,22 @@
 name: CI
 on:
-  pull_request:
   workflow_dispatch:
+  pull_request:
+
+  # triggering CI default branch improves caching
+  # see https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
   push:
     branches:
       - main
+      -
 jobs:
   CI:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-node@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version-file: 'pan-domain-node/.nvmrc'
           cache: npm
@@ -28,9 +32,9 @@ jobs:
 
           popd
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '21'
           distribution: 'corretto'
           cache: 'sbt'
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,14 @@
-import sbt._
-import sbt.Keys._
-import Dependencies._
-import sbtrelease._
-import ReleaseStateTransformations._
-import xerial.sbt.Sonatype._
-import play.sbt.PlayImport.PlayKeys._
+import sbt.*
+import sbt.Keys.*
+import Dependencies.*
+import sbtrelease.*
+import ReleaseStateTransformations.*
+import xerial.sbt.Sonatype.*
+import play.sbt.PlayImport.PlayKeys.*
 import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 val scala212 = "2.12.19"
-val scala213 = "2.13.13"
+val scala213 = "2.13.14"
 
 ThisBuild / scalaVersion := scala213
 


### PR DESCRIPTION
Panda's [CI build was warning us](https://github.com/guardian/pan-domain-authentication/actions/runs/10919393000):

> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, actions/setup-node@v3, actions/setup-java@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

![image](https://github.com/user-attachments/assets/3c074bdb-3b4b-4c19-9e20-1d0e07c58e63)


...better to use the current versions of those actions!
