### PR TITLE
changesets: set workflow default working-directory

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -14,6 +14,10 @@ jobs:
       id-token: write
       pull-requests: write
 
+    defaults:
+      run:
+        working-directory: pan-domain-node
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -22,20 +26,16 @@ jobs:
           cache: npm
 
       - name: Install
-        working-directory: pan-domain-node
         run: npm ci
 
       - name: Build
-        working-directory: pan-domain-node
         run: npm run build
 
       - name: Test
-        working-directory: pan-domain-node
         run: npm run test
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        working-directory: pan-domain-node
         uses: changesets/action@v1
         with:
           publish: npx changeset publish


### PR DESCRIPTION
github complains that the `uses` directive is invalid in the final step, I cant see why so I can only conclude that you arent allowed to set a working-directory for a `uses` step. which is madness. instead lets try and set the working-directory once for the entire worklow


@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->