### PR TITLE
Set working directory everywhere

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version-file: "pan-domain-node/.nvmrc"
           cache: npm
+          cache-dependency-path: "pan-domain-node/package-lock.json"
 
       - name: Install
         run: npm ci
@@ -41,6 +42,7 @@ jobs:
           publish: npx changeset publish
           title: "🦋 Release package updates"
           commit: "Bump package version"
+          cwd: "pan-domain-node"
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Actions appear not to inherit the working directory settings, which seems to only apply to run: commands.

Instead I guess you need each action to offer an input which sets a different working directory, and to set it in each action. Lovely.


@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->