### PR TITLE
Set up the gu-changesets-release bot

### DIFF
--- a/.github/workflows/node-release.yml
+++ b/.github/workflows/node-release.yml
@@ -35,6 +35,18 @@ jobs:
       - name: Test
         run: npm run test
 
+      - name: Use GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.GU_CHANGESETS_APP_ID }}
+          private-key: ${{ secrets.GU_CHANGESETS_PRIVATE_KEY }}
+
+      - name: Set git user to Gu Changesets app
+        run: |
+          git config user.name "gu-changesets-release-pr[bot]"
+          git config user.email "gu-changesets-release-pr[bot]@users.noreply.github.com"
+
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
@@ -43,7 +55,8 @@ jobs:
           title: "🦋 Release package updates"
           commit: "Bump package version"
           cwd: "pan-domain-node"
+          setupGitUser: false
 
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
@guardian/digital-cms

The default github-actions user can raise PRs, but workflows will not run on those PRs, making them unmergeable (at least without relaxing branch protection rules, which would be a shame)

It looks like other repos like csnx switch into a different github account before running the changesets action - https://github.com/guardian/csnx/blob/ea2e0c3cb03d5ac8d658c9bd119479e9456e4143/.github/workflows/changesets.yml#L33-L42

Adopt that pattern for ourselves (I'll also add this to the documentation which doesn't mention this point!)

Requires https://github.com/guardian/github-secret-access/pull/67

<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->