### PR TITLE
configure changesets to publish package as public

### DIFF
--- a/pan-domain-node/.changeset/config.json
+++ b/pan-domain-node/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []


### PR DESCRIPTION
@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->

The default changesets generated config apparently sets the package visibility as restricted - we intend to publish this package publicly; so set that value here...