### PR TITLE
key-rotation: monitor non-active-key use

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ lazy val root = Project("pan-domain-auth-root", file(".")).aggregate(
   exampleApp
 ).settings(
   publish / skip := true,
-  // releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
+  releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
   releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
   releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/internal/FrequencyMap.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/internal/FrequencyMap.scala
@@ -1,0 +1,17 @@
+package com.gu.pandomainauth.internal
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.LongAdder
+import scala.jdk.CollectionConverters._
+
+/**
+ * Used for counting in realtime how often things occur (eg specific public keys are used)
+ * The class is thread-safe for concurrent updates.
+ */
+class FrequencyMap[K] {
+  private val freqs: ConcurrentHashMap[K, LongAdder] = new ConcurrentHashMap[K, LongAdder]()
+
+  def increment(k: K): Unit = freqs.computeIfAbsent(k, _ => new LongAdder()).increment()
+
+  def snapshot(): Map[K, Long] = freqs.asScala.mapValues(_.sum).toMap
+}

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/internal/KeyHashId.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/internal/KeyHashId.scala
@@ -1,0 +1,19 @@
+package com.gu.pandomainauth.internal
+
+import com.google.common.hash.Hashing
+
+import java.security.PublicKey
+
+case class KeyHashId(id: String) {
+  override val toString = s"'$id'"
+}
+
+object KeyHashId {
+  // Avoid collisions when used with hourly new keys over the course of a year
+  val NumberOfDigitsNecessaryToAvoidBirthdayCollisions: Int = 5
+
+  def calculateFor(publicKey: PublicKey): KeyHashId = new KeyHashId(
+    BigInt(Hashing.sha256().hashBytes(publicKey.getEncoded).asBytes()).abs.toString(36)
+      .take(NumberOfDigitsNecessaryToAvoidBirthdayCollisions)
+  )
+}

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/internal/NonActiveKeyMonitoring.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/internal/NonActiveKeyMonitoring.scala
@@ -1,0 +1,29 @@
+package com.gu.pandomainauth.internal
+
+import com.google.common.util.concurrent.RateLimiter
+import org.slf4j.LoggerFactory
+
+class NonActiveKeyMonitoring {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  private val activeFrequency: FrequencyMap[Boolean] = new FrequencyMap[Boolean]()
+  private val keyFrequency: FrequencyMap[KeyHashId] = new FrequencyMap[KeyHashId]()
+
+  private val rateLimiter = RateLimiter.create(1.0d / 10)
+
+  def monitor(usedKey: KeyHashId, activeKey: KeyHashId): Unit = {
+    val isActive = usedKey == activeKey
+    activeFrequency.increment(isActive)
+    keyFrequency.increment(usedKey)
+
+    if (!isActive) { // an accepted key, but not the _current_ one - either old or new...
+      if (rateLimiter.tryAcquire()) {
+        logger.warn(s"NON_ACTIVE_KEY_USED (used=$usedKey, active=$activeKey): active_freq=${activeFrequency.snapshot()} key_freq=${keyFrequency.snapshot()}")
+      }
+    }
+  }
+}
+
+object NonActiveKeyMonitoring {
+  val instance = new NonActiveKeyMonitoring
+}

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/CryptoConfTest.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/CryptoConfTest.scala
@@ -1,40 +1,67 @@
 package com.gu.pandomainauth
 
+import com.gu.pandomainauth.SampleConf.loadExample
+import com.gu.pandomainauth.service.CryptoConf
 import com.gu.pandomainauth.service.CryptoConf.{SettingsReader, SigningAndVerification}
 import com.gu.pandomainauth.service.TestKeys.testPublicKey
-import org.scalatest.EitherValues
+import org.scalatest.{EitherValues, OptionValues}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.nio.charset.StandardCharsets.UTF_8
 
+object SampleConf {
+  def loadExample(name: String): SigningAndVerification = {
+    val settingsText =
+      new String(getClass.getResourceAsStream(s"/crypto-conf-rotation-example/$name.settings").readAllBytes(), UTF_8)
+    SettingsReader(Settings.extractSettings(settingsText).toOption.get).signingAndVerificationConf.toOption.get
+  }
+}
 
-class CryptoConfTest extends AnyFreeSpec with Matchers with EitherValues {
+class CryptoConfTest extends AnyFreeSpec with Matchers with EitherValues with OptionValues {
+  val legacyConf = loadExample("0.legacy")
+  val rotationUpcomingConf = loadExample("1.rotation-upcoming")
+  val rotationInProgressConf = loadExample("2.rotation-in-progress")
+  val rotationCompleteConf = loadExample("3.rotation-complete")
+
   "loading crypto configuration" - {
     "follow a safe set of transition steps" in {
-      val legacyConf = loadExample("0.legacy")
       legacyConf.alsoAccepted shouldBe empty
 
-      val rotationUpcomingConf = loadExample("1.rotation-upcoming")
       rotationUpcomingConf.activeKeyPair should === (legacyConf.activeKeyPair)
       rotationUpcomingConf.alsoAccepted should not be empty
       val expectedAcceptedPublicKeys = rotationUpcomingConf.activeKeyPair.publicKey +: rotationUpcomingConf.alsoAccepted
       rotationUpcomingConf.acceptedPublicKeys should === (expectedAcceptedPublicKeys)
 
-      val rotationInProgressConf = loadExample("2.rotation-in-progress")
       rotationInProgressConf.activeKeyPair should !== (legacyConf.activeKeyPair)
       rotationInProgressConf.alsoAccepted shouldBe Seq(legacyConf.activeKeyPair.publicKey)
 
-      val rotationCompleteConf = loadExample("3.rotation-complete")
       rotationCompleteConf.activeKeyPair should === (rotationInProgressConf.activeKeyPair)
       rotationCompleteConf.alsoAccepted shouldBe empty
     }
-  }
 
-  private def loadExample(name: String): SigningAndVerification = {
-    val settingsText =
-      new String(getClass.getResourceAsStream(s"/crypto-conf-rotation-example/$name.settings").readAllBytes(), UTF_8)
-    SettingsReader(Settings.extractSettings(settingsText).value).signingAndVerificationConf.value
+    "have transitions that are reported as safe" in {
+      val stages = Seq(legacyConf, rotationUpcomingConf, rotationInProgressConf, rotationCompleteConf)
+      for {
+        (before, after) <- stages.zip(stages.tail)
+      } {
+        val change = CryptoConf.Change.compare(before, after).value
+        println(change.summary)
+        change.isBreakingChange shouldBe false
+      }
+    }
+
+    "report a bad transition if the old active key is not still tolerated" in {
+      val change = CryptoConf.Change.compare(rotationUpcomingConf, rotationCompleteConf).value
+      println(change.summary)
+      change.isBreakingChange shouldBe true
+    }
+
+    "report a bad transition if the new active key wasn't already accepted by the old config" in {
+      val change = CryptoConf.Change.compare(legacyConf, rotationInProgressConf).value
+      println(change.summary)
+      change.isBreakingChange shouldBe true
+    }
   }
 
   "CryptoConf.SettingsReader" - {

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/internal/KeyHashIdTest.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/internal/KeyHashIdTest.scala
@@ -1,0 +1,29 @@
+package com.gu.pandomainauth.internal
+
+import com.gu.pandomainauth.SampleConf.loadExample
+import com.gu.pandomainauth.internal.KeyHashId.calculateFor
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class KeyHashIdTest extends AnyFlatSpec with Matchers {
+
+  val rotationUpcoming = loadExample("1.rotation-upcoming")
+  val rotationInProgress = loadExample("2.rotation-in-progress")
+
+
+  val oldKey = KeyHashId("tudwv")
+  val newKey = KeyHashId("povb6")
+
+  "key hash ids" should "be stable so that we can use them as a simple text identifier for public keys" in {
+    rotationUpcoming.acceptedPublicKeys.map(calculateFor) shouldBe Seq(oldKey, newKey)
+
+    newKey shouldNot be(oldKey)
+    newKey.id shouldNot startWith(oldKey.id.take(1)) // the hashCode on PublicKey seems bad enough that this happens
+
+    calculateFor(rotationUpcoming.activePublicKey) shouldBe oldKey
+    rotationUpcoming.alsoAccepted.map(calculateFor) shouldBe Seq(newKey)
+
+    calculateFor(rotationInProgress.activePublicKey) shouldBe newKey
+    rotationInProgress.alsoAccepted.map(calculateFor) shouldBe Seq(oldKey)
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,8 @@ object Dependencies {
 
   val cryptoDependencies = Seq(
     "org.bouncycastle" % "bcprov-jdk18on" % "1.78.1",
-    "commons-codec" % "commons-codec" % "1.17.1"
+    "commons-codec" % "commons-codec" % "1.17.1",
+    "com.google.guava" % "guava" % "33.4.0-jre"
   )
 
   val testDependencies = Seq("org.scalatest" %% "scalatest" % "3.2.19" % Test)


### PR DESCRIPTION
As we perform the key-rotation enabled by #150, it'll be good to have insight into how many users are still using cookies signed by old keys (to be precise, keys that are not the _active_ key) - we should see it tail off within the space of 1 hour. 

This change adds monitoring that records how often cookies signed by non-active keys are being validated - when a non-active key is used, the stats are logged out.

> NON_ACTIVE_KEY_USED (used='1xpqc', active='6k065'): active_freq=Map(false -> 22, true -> 3) key_freq=Map('1xpqc' -> 25)

### Guava, rate-limiting & logging

The frequency of logging is throttled by Guava's [`RateLimiter`](https://github.com/google/guava/blob/master/guava/src/com/google/common/util/concurrent/RateLimiter.java) to once every 10 seconds per JVM. Consequently, **this update adds [Guava](https://github.com/google/guava) as a dependency**.

## Testing

I've tried this PR out using a preview release on [tagmanager.code.dev-gutools.co.uk](https://tagmanager.code.dev-gutools.co.uk/), where it worked as intended:

* https://github.com/guardian/tagmanager/pull/547
