### PR TITLE
Adapt `key-rotation` script for Scala 3, stop it from building under Scala 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ the `CryptoConfForRotation` Scala script on that `.settings` file to generate a 
 required config files for each step:
 
 ```
-pan-domain-auth-verification / Test / runMain com.gu.pandomainauth.CryptoConfForRotation current-from-s3.settings
+key-rotation/run current-from-s3.settings
 ```
 
 3 new partial `.settings` files will be created, providing _just_ the updated crypto settings - you'll need to

--- a/build.sbt
+++ b/build.sbt
@@ -7,66 +7,60 @@ import play.sbt.PlayImport.PlayKeys.*
 import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 ThisBuild / scalaVersion := "3.3.5"
-ThisBuild / crossScalaVersions := Seq(
-  scalaVersion.value,
-  "2.13.16"
-)
+val crossCompileScalaVersions = crossScalaVersions := Seq(scalaVersion.value, "2.13.16")
 
 val commonSettings = Seq(
-  organization := "com.gu",
-  licenses := Seq(License.Apache2),
   Test / fork := false,
-  scalacOptions := Seq(
-    "-feature",
-    "-deprecation",
-    "-release:11"
-  ),
   libraryDependencies ++= testDependencies,
   Test / testOptions +=
     Tests.Argument(TestFrameworks.ScalaTest, "-u", s"test-results/scala-${scalaVersion.value}", "-o")
 )
 
-def subproject(path: String): Project =
-  Project(path, file(path)).settings(commonSettings: _*)
-
-lazy val panDomainAuthVerification = subproject("pan-domain-auth-verification")
-  .settings(
-    libraryDependencies
-      ++= cryptoDependencies
-      ++ awsDependencies
-      ++ testDependencies
-      ++ loggingDependencies,
-  )
-
-lazy val panDomainAuthCore = subproject("pan-domain-auth-core")
-  .dependsOn(panDomainAuthVerification)
-  .settings(
-    libraryDependencies
-      ++= awsDependencies
-      ++ googleDirectoryApiDependencies
-      ++ cryptoDependencies
-      ++ testDependencies,
-  )
-
-def playBasedProject(playVersion: PlayVersion, projectPrefix: String, srcFolder: String) =
-  subproject(s"$projectPrefix-${playVersion.suffix}").settings(
-    sourceDirectory := (ThisBuild / baseDirectory).value / srcFolder / "src"
-  )
-
-def playSupportFor(playVersion: PlayVersion) =
-  playBasedProject(playVersion, "pan-domain-auth", "pan-domain-auth-play").settings(
-    libraryDependencies ++= playVersion.playLibs
-  ).dependsOn(panDomainAuthCore)
-
-lazy val panDomainAuthHmac = Project(s"panda-hmac-core", file("hmac/core")).settings(commonSettings).settings(
-  libraryDependencies += hmacHeaders
+val artifactProductionSettings = Seq(
+  crossCompileScalaVersions, // mostly, we only want to cross-compile Scala version for projects that create artifacts
+  organization := "com.gu",
+  licenses := Seq(License.Apache2),
+  scalacOptions := Seq(
+    "-feature",
+    "-deprecation",
+    "-release:11"
+  ),
 )
 
+def directSubfolderProject(path: String): Project = Project(path, file(path)).settings(commonSettings)
+
+lazy val panDomainAuthVerification = directSubfolderProject("pan-domain-auth-verification")
+  .settings(
+    artifactProductionSettings,
+    libraryDependencies ++= cryptoDependencies ++ awsDependencies ++ loggingDependencies
+  )
+
+lazy val panDomainAuthCore = directSubfolderProject("pan-domain-auth-core")
+  .dependsOn(panDomainAuthVerification)
+  .settings(
+    artifactProductionSettings,
+    libraryDependencies ++= googleDirectoryApiDependencies
+  )
+
+def playSupportFor(playVersion: PlayVersion) = directSubfolderProject(s"pan-domain-auth-${playVersion.suffix}")
+  .dependsOn(panDomainAuthCore)
+  .settings(
+    artifactProductionSettings,
+    sourceDirectory := (ThisBuild / baseDirectory).value / "pan-domain-auth-play" / "src",
+    libraryDependencies ++= playVersion.playLibs
+  )
+
+def hmacProject(nameSuffix: String, subFolderPath: String) =
+  Project(s"panda-hmac-$nameSuffix", file(s"hmac/$subFolderPath")).settings(
+    commonSettings,
+    artifactProductionSettings // all HMAC projects are published
+  )
+
 def hmacPlayProject(playVersion: PlayVersion, playSupportProject: Project) =
-  Project(s"panda-hmac-${playVersion.suffix}", file(s"hmac/play/${playVersion.suffix}"))
-    .settings(commonSettings).settings(
-    libraryDependencies ++= hmacHeaders +: testDependencies
-  ).dependsOn(playSupportProject, panDomainAuthHmac)
+  hmacProject(playVersion.suffix, s"play/${playVersion.suffix}")
+    .dependsOn(playSupportProject, panDomainAuthHmac)
+
+lazy val panDomainAuthHmac = hmacProject("core", "core").settings(libraryDependencies += hmacHeaders)
 
 lazy val panDomainAuthPlay_2_9 = playSupportFor(PlayVersion.V29)
 lazy val panDomainAuthHmac_2_9 = hmacPlayProject(PlayVersion.V29, panDomainAuthPlay_2_9)
@@ -74,13 +68,20 @@ lazy val panDomainAuthHmac_2_9 = hmacPlayProject(PlayVersion.V29, panDomainAuthP
 lazy val panDomainAuthPlay_3_0 = playSupportFor(PlayVersion.V30)
 lazy val panDomainAuthHmac_3_0 = hmacPlayProject(PlayVersion.V30, panDomainAuthPlay_3_0)
 
-lazy val exampleApp = subproject("pan-domain-auth-example")
+lazy val exampleApp = directSubfolderProject("pan-domain-auth-example")
   .enablePlugins(PlayScala)
   .dependsOn(panDomainAuthPlay_3_0)
   .settings(
+    crossCompileScalaVersions, // IntelliJ seems to require this to successfully import the sbt project
     libraryDependencies ++= awsDependencies :+ ws,
     publish / skip := true,
     playDefaultPort := 9500
+  )
+
+lazy val keyRotation = directSubfolderProject("key-rotation")
+  .dependsOn(panDomainAuthVerification)
+  .settings(
+    publish / skip := true
   )
 
 lazy val root = Project("pan-domain-auth-root", file(".")).aggregate(
@@ -91,10 +92,11 @@ lazy val root = Project("pan-domain-auth-root", file(".")).aggregate(
   panDomainAuthHmac,
   panDomainAuthHmac_2_9,
   panDomainAuthHmac_3_0,
-  exampleApp
+  exampleApp,
+  keyRotation
 ).settings(
   publish / skip := true,
-  // releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
+  releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value,
   releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
   releaseProcess := Seq[ReleaseStep](
     checkSnapshotDependencies,

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/Settings.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/Settings.scala
@@ -32,7 +32,7 @@ trait FailureWithCause extends SettingsFailure {
 }
 
 case class SettingsDownloadFailure(cause: Throwable) extends FailureWithCause {
-  override val description: String = "Unable to download public key"
+  override val description: String = "Unable to access settings file"
 }
 
 case class MissingSetting(name: String) extends SettingsFailure {

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/CryptoConfForRotation.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/CryptoConfForRotation.scala
@@ -2,7 +2,7 @@ package com.gu.pandomainauth
 
 import com.gu.pandomainauth.service.CryptoConf.SigningAndVerification
 import com.gu.pandomainauth.service.{CryptoConf, KeyPair}
-import org.scalatest.EitherValues
+import org.scalatest.EitherValues.*
 
 import java.io.FileInputStream
 import java.nio.file.Files
@@ -14,7 +14,7 @@ import java.time.temporal.ChronoUnit.SECONDS
 import java.util.Base64
 
 /**
- * This class can be run from the sbt console with `pan-domain-auth-verification / Test / run`.
+ * This function can be run from the sbt console with `pan-domain-auth-verification / Test / run`.
  *
  * You need to supply the _current_ Panda .settings file as the command line argument, eg:
  *
@@ -23,13 +23,11 @@ import java.util.Base64
  * settings
  * }}}
  */
-object CryptoConfForRotation extends App with EitherValues {
+@main def run(settingsFilePath: String) = {
 
   val base64Encoder = Base64.getEncoder
 
-  args.headOption.fold(
-    Console.err.println("\nYou must supply the path to the current Panda .settings file, downloaded from S3.\n")
-  )(generateForExistingConf)
+  generateForExistingConf(settingsFilePath)
 
   def generateForExistingConf(pathForCurrentConf: String): Unit = {
     val keyPairGenerator: KeyPairGenerator = {


### PR DESCRIPTION
## Problem

The Scala script for generating [new key-rotation config](https://github.com/guardian/pan-domain-authentication/pull/150) was broken by the addition of Scala 3 support in https://github.com/guardian/pan-domain-authentication/pull/165.

This was because the script used the preferred Scala 2 syntax for creating CLI apps: the `App` trait which (somewhat magically) provides an `args` value using the `DelayedInit` trait. Scala 3 removed support for that trait, meaning that `args` was no longer populated - giving not a compile-time error, but a cryptic runtime error:

```
Exception in thread "sbt-bg-threads-1" java.lang.ExceptionInInitializerError
        at com.gu.pandomainauth.CryptoConfForRotation.main(CryptoConfForRotation.scala)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at sbt.Run.invokeMain(Run.scala:144)
        at sbt.Run.execute$1(Run.scala:94)
        at sbt.Run.$anonfun$runWithLoader$5(Run.scala:121)
        at sbt.Run$.executeSuccess(Run.scala:187)
        at sbt.Run.runWithLoader(Run.scala:121)
        at sbt.Defaults$.$anonfun$bgRunTask$6(Defaults.scala:2030)
        at sbt.Defaults$.$anonfun$termWrapper$2(Defaults.scala:1969)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
        at scala.util.Try$.apply(Try.scala:213)
        at sbt.internal.BackgroundThreadPool$BackgroundRunnable.run(DefaultBackgroundJobService.scala:367)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.NullPointerException
        at java.base/java.lang.reflect.Array.getLength(Native Method)
        at scala.collection.ArrayOps$.headOption$extension(ArrayOps.scala:219)
        at com.gu.pandomainauth.CryptoConfForRotation$.<clinit>(CryptoConfForRotation.scala:30)
        ... 16 more
```

We want the script to run under Scala 3, and use the new Scala 3 syntax for CLI apps (ie the `@main` method annotation, and [args-from-method-parameters](https://docs.scala-lang.org/scala3/book/methods-main-methods.html#command-line-arguments)), but leaving the script where it was (inside the tests of `pan-domain-auth-verification`) meant that when CI ran `++test`, `sbt` would attempt to compile the script under both Scala 2 & 3, which would fail on Scala 2 where obviously the Scala 3 syntax wasn't supported.

## Fix

There does exist [syntax that works for both Scala 2 & Scala 3](https://docs.scala-lang.org/scala3/book/methods-main-methods.html#backwards-compatibility-with-scala-2), but really, it probably makes sense to move the script out to its own subproject, where it will only be compiled for Scala 3 and additionally can be invoked from the sbt console much more concisely:

#### Before

```
pan-domain-auth-verification / Test / run panda.settings
```

#### After

```
key-rotation/run panda.settings
```


I've also tried to tidy up the sbt build script a bit too!