### PR TITLE
Set 24-hour grace period as the default

### DIFF
--- a/pan-domain-auth-example/app/VerifyExample.scala
+++ b/pan-domain-auth-example/app/VerifyExample.scala
@@ -45,7 +45,7 @@ object VerifyExample {
   val cacheValidation = false
 
   // To verify, call the authStatus method with the encoded cookie data
-  val status = PanDomain.authStatus("<<cookie data>>>", verification, validateUser, apiGracePeriod, system, cacheValidation, forceExpiry = false)
+  val status = PanDomain.authStatus("<<cookie data>>>", verification, validateUser, system, cacheValidation, forceExpiry = false)
 
   status match {
     case Authenticated(_) | GracePeriod(_) =>

--- a/pan-domain-auth-example/app/VerifyExample.scala
+++ b/pan-domain-auth-example/app/VerifyExample.scala
@@ -29,10 +29,6 @@ object VerifyExample {
   // The name of this particular application
   val system = "test"
 
-  // Adding a grace period allows for XHR requests to continue for a period if there a delay between a user expiring and
-  // their re-authentication with the OAuth provider, especially if this is done by inserting an iframe client-side.
-  val apiGracePeriod = Duration.ZERO
-
   // Check the user is valid for your app by inspecting the fields provided
   // The `PanDomain.guardianValidation` helper should be used for Guardian apps
   def validateUser(authUser: AuthenticatedUser): Boolean = {

--- a/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -9,8 +9,6 @@ import play.api.mvc.Results._
 import play.api.mvc._
 
 import java.net.{URLDecoder, URLEncoder}
-import java.time.Duration
-import java.time.Duration.ZERO
 import scala.concurrent.{ExecutionContext, Future}
 
 class UserRequest[A](val user: User, request: Request[A]) extends WrappedRequest[A](request)
@@ -62,18 +60,6 @@ trait AuthActions {
     * @return true if you want to only check the validity of the user once for the lifetime of the user's auth session
     */
   def cacheValidation: Boolean = false
-
-  /**
-    * Adding an expiry extension to `APIAuthAction`s allows for a delay between an applications authentication and their
-    * respective API XHR calls expiring.
-    *
-    * By default this is 0 and thus disabled.
-    *
-    * This is particularly useful for SPAs where users have third party cookies disabled.
-    *
-    * @return the amount of delay between App and API expiry in milliseconds
-    */
-  def apiGracePeriod: Duration = ZERO
 
   /**
     * The auth callback url. This is where the OAuth provider will send the user after authentication.
@@ -237,7 +223,7 @@ trait AuthActions {
     */
   def extractAuth(request: RequestHeader): AuthenticationStatus = {
     readCookie(request).map { cookie =>
-      PanDomain.authStatus(cookie.cookie.value, settings.signingAndVerification, validateUser, apiGracePeriod, system, cacheValidation, cookie.forceExpiry)
+      PanDomain.authStatus(cookie.cookie.value, settings.signingAndVerification, validateUser, system, cacheValidation, cookie.forceExpiry)
     } getOrElse NotAuthenticated
   }
 

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PanDomain.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PanDomain.scala
@@ -5,14 +5,39 @@ import com.gu.pandomainauth.service.CookieUtils
 import com.gu.pandomainauth.service.CryptoConf.Verification
 
 import java.time.Duration
+import java.time.Duration.ofHours
 
 
 object PanDomain {
+
+  /**
+   * The Panda cookie expires after one hour, and top-level navigation that
+   * requests HTML will trigger a re-auth and refresh the session after this point.
+   *
+   * However, fetch requests to API endpoints are unable to do this re-auth,
+   * and mechanisms for refreshing in the background without top-level nav or popups
+   * (such as iframes) are increasingly locked down by third-party cookie restrictions.
+   *
+   * So for API requests, we provide a further 24 hours grace period within which requests
+   * will continue to work, and the app UI should signal to the user that they need
+   * to refresh the page to re-auth.
+   *
+   * Panda cookie:  issued       expires
+   *                |-- 1 hour --|
+   * Grace period:               [------------- 24 hours -------------]
+   * API request:   [-succeeds----------------------------------------][-fails---->
+   * Top-level nav: [-succeeds--][-fails-but-would-trigger-re-auth---------------->
+   *
+   * @return delay between cookie expiry and API requests failing
+   */
+  val DefaultApiGracePeriod: Duration = ofHours(24)
+
   /**
    * Check the authentication status of the provided credentials by examining the signed cookie data.
    */
   def authStatus(cookieData: String, verification: Verification, validateUser: AuthenticatedUser => Boolean,
-                 apiGracePeriod: Duration, system: String, cacheValidation: Boolean, forceExpiry: Boolean): AuthenticationStatus = {
+                 system: String, cacheValidation: Boolean, forceExpiry: Boolean,
+                 apiGracePeriod: Duration = DefaultApiGracePeriod): AuthenticationStatus = {
     CookieUtils.parseCookieData(cookieData, verification).fold(InvalidCookie(_), { authedUser =>
       checkStatus(authedUser, validateUser, apiGracePeriod, system, cacheValidation, forceExpiry)
     })

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/service/CookieUtilsTest.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/service/CookieUtilsTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{EitherValues, OptionValues}
 
+import java.time.Duration.ofHours
 import java.time.Instant.now
 import java.time.temporal.ChronoUnit.MILLIS
 
@@ -22,7 +23,7 @@ class CookieUtilsTest extends AnyFreeSpec with Matchers with EitherValues with O
       "another"),
     // The expiry is serialised to millisecond accuracy
     // so this needs to be at the same precision for comparison.
-    now().plusMillis(86400).truncatedTo(MILLIS),
+    now().plus(ofHours(1)).truncatedTo(MILLIS),
     multiFactor = true
   )
 


### PR DESCRIPTION
# Background
The Panda authentication cookie **expires after 1 hour**, and top-level navigation requests (page loads) trigger automatic re-authentication after this point.

Unfortunately API requests **cannot trigger re-authentication on their own**, and background refresh mechanisms (e.g. iframe-based method used by [Pandular](https://github.com/guardian/pandular)) are increasingly blocked by browsers due to third-party cookie restrictions.

```
Panda cookie:  issued       expires
               |-- 1 hour --|
Grace period:               [------------- 24 hours -------------]
API request:   [-succeeds----------------------------------------][-fails---->
Top-level nav: [-succeeds--][-fails-but-would-trigger-re-auth---------------->
```

We are opting to:

####  1. Set a grace period of 24 hours in individual apps
This allows API requests to continue working for 24 hours after cookie expiry, meaning a cookie can be used to authenticate API requests for 25 hours after it is issued. This has so far been done in:
- Composer:
  - https://github.com/guardian/flexible-content/pull/5112
  - https://github.com/guardian/flexible-content/pull/5096
- Grid:
  - https://github.com/guardian/grid/pull/4405

####  2. Warn the user in the app UI when they are near the end of the grace period
And ideally give them a call to action to re-authenticate by popping open a new tab. This has so far been done in:
- Composer:
  - https://github.com/guardian/flexible-content/pull/5150
  - https://github.com/guardian/flexible-content/pull/5210

We want to move towards **enforcing this pattern consistently across tools**, so we are **setting the default within the library to 24 hours.**

See [this doc](https://docs.google.com/document/d/1Rn76R5TgjYDpJ_1C4TrBYCWqYWhk0o3I-vS_rpamdnQ/edit?tab=t.0#heading=h.sfwn5i51mpsl) for more details

# Changes
## 1. Move `apiGracePeriod` from the Play-specific `AuthActions` trait into the `PanDomain` object
We don't want this notion coupled to Play. In some apps, e.g. [s3 uploader](https://github.com/guardian/s3-upload/blob/a976a57c3804f65327a9de35e37b8e4cadc09d9c/app/lib/PanAuth.scala#L31-L39), the `PanDomain.checkAuth` function is used directly instead of the Play-specific `AuthActions` trait.

We want the default API grace period to be available regardless of which abstraction you use.

## 2. Increase default grace period to 24 hours
As described above, this is to encourage our default pattern of allowing the user 24 hours to perform a top-level nav and get a fresh auth, instead of rejecting API requests after 1 hour.

## 3. Add grace-period tests
Since we changed the logic, we wanted some extra reassurance.

We added some extra tests around expired vs grace period, checking the default behaviour but also the behaviour when a custom grace period is set.