### PR TITLE
Strongly-type time fields

### DIFF
--- a/pan-domain-auth-example/app/VerifyExample.scala
+++ b/pan-domain-auth-example/app/VerifyExample.scala
@@ -6,6 +6,8 @@ import com.gu.pandomainauth.model.{Authenticated, AuthenticatedUser, GracePeriod
 import com.gu.pandomainauth.service.CryptoConf
 import com.gu.pandomainauth.{PanDomain, PublicSettings, Settings}
 
+import java.time.Duration
+
 object VerifyExample {
   // Change this to point to the S3 bucket and key for the settings file
   val settingsFileKey = "local.dev-gutools.co.uk.settings.public"
@@ -29,7 +31,7 @@ object VerifyExample {
 
   // Adding a grace period allows for XHR requests to continue for a period if there a delay between a user expiring and
   // their re-authentication with the OAuth provider, especially if this is done by inserting an iframe client-side.
-  val apiGracePeriod = 0
+  val apiGracePeriod = Duration.ZERO
 
   // Check the user is valid for your app by inspecting the fields provided
   // The `PanDomain.guardianValidation` helper should be used for Guardian apps

--- a/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
+++ b/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/action/Actions.scala
@@ -9,6 +9,8 @@ import play.api.mvc.Results._
 import play.api.mvc._
 
 import java.net.{URLDecoder, URLEncoder}
+import java.time.Duration
+import java.time.Duration.ZERO
 import scala.concurrent.{ExecutionContext, Future}
 
 class UserRequest[A](val user: User, request: Request[A]) extends WrappedRequest[A](request)
@@ -71,7 +73,7 @@ trait AuthActions {
     *
     * @return the amount of delay between App and API expiry in milliseconds
     */
-  def apiGracePeriod: Long = 0 // ms
+  def apiGracePeriod: Duration = ZERO
 
   /**
     * The auth callback url. This is where the OAuth provider will send the user after authentication.

--- a/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/service/OAuth.scala
+++ b/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/service/OAuth.scala
@@ -8,6 +8,7 @@ import play.api.mvc.{RequestHeader, Result}
 
 import java.math.BigInteger
 import java.security.SecureRandom
+import java.time.Instant
 import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
@@ -96,8 +97,8 @@ class OAuth(config: OAuthSettings, system: String, redirectUrl: String)(implicit
                   ),
                   authenticatingSystem = system,
                   authenticatedIn = Set(system),
-                  jwt.claims.exp * 1000,
-                  false
+                  expires = Instant.ofEpochSecond(jwt.claims.exp), // https://stackoverflow.com/a/39926886/438886
+                  multiFactor = false
                 )
               }
             }

--- a/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/service/OAuth.scala
+++ b/pan-domain-auth-play/src/main/scala/com/gu/pandomainauth/service/OAuth.scala
@@ -97,7 +97,11 @@ class OAuth(config: OAuthSettings, system: String, redirectUrl: String)(implicit
                   ),
                   authenticatingSystem = system,
                   authenticatedIn = Set(system),
-                  expires = Instant.ofEpochSecond(jwt.claims.exp), // https://stackoverflow.com/a/39926886/438886
+                  // The JWT standard specifies that `exp` is a `NumericDate`,
+                  // which is defined as an epoch time in *seconds*
+                  // (unlike the Panda cookie `expires` which is in milliseconds)
+                  // https://www.rfc-editor.org/rfc/rfc7519#section-4.1.4
+                  expires = Instant.ofEpochSecond(jwt.claims.exp),
                   multiFactor = false
                 )
               }

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PanDomain.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PanDomain.scala
@@ -4,20 +4,22 @@ import com.gu.pandomainauth.model._
 import com.gu.pandomainauth.service.CookieUtils
 import com.gu.pandomainauth.service.CryptoConf.Verification
 
+import java.time.Duration
+
 
 object PanDomain {
   /**
    * Check the authentication status of the provided credentials by examining the signed cookie data.
    */
   def authStatus(cookieData: String, verification: Verification, validateUser: AuthenticatedUser => Boolean,
-                 apiGracePeriod: Long, system: String, cacheValidation: Boolean, forceExpiry: Boolean): AuthenticationStatus = {
+                 apiGracePeriod: Duration, system: String, cacheValidation: Boolean, forceExpiry: Boolean): AuthenticationStatus = {
     CookieUtils.parseCookieData(cookieData, verification).fold(InvalidCookie(_), { authedUser =>
       checkStatus(authedUser, validateUser, apiGracePeriod, system, cacheValidation, forceExpiry)
     })
   }
 
   private def checkStatus(authedUser: AuthenticatedUser, validateUser: AuthenticatedUser => Boolean,
-                          apiGracePeriod: Long, system: String, cacheValidation: Boolean,
+                          apiGracePeriod: Duration, system: String, cacheValidation: Boolean,
                           forceExpiry: Boolean): AuthenticationStatus = {
 
     if (authedUser.isExpired && authedUser.isInGracePeriod(apiGracePeriod)) {

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/model/AuthenticatedUser.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/model/AuthenticatedUser.scala
@@ -1,9 +1,11 @@
 package com.gu.pandomainauth.model
 
-import java.util.Date
+import java.time.Instant.now
+import java.time.{Duration, Instant}
+import scala.math.Ordering.Implicits._
 
-case class AuthenticatedUser(user: User, authenticatingSystem: String, authenticatedIn: Set[String], expires: Long, multiFactor: Boolean) {
+case class AuthenticatedUser(user: User, authenticatingSystem: String, authenticatedIn: Set[String], expires: Instant, multiFactor: Boolean) {
 
-  def isExpired = expires < new Date().getTime
-  def isInGracePeriod(period: Long) = (expires + period) > new Date().getTime
+  def isExpired = now() > expires
+  def isInGracePeriod(period: Duration) = now() < (expires plus period)
 }

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/CookieUtils.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/service/CookieUtils.scala
@@ -4,6 +4,7 @@ import com.gu.pandomainauth.model.{AuthenticatedUser, User}
 import com.gu.pandomainauth.service.CookieUtils.CookieIntegrityFailure.{MalformedCookieText, MissingOrMalformedUserData, SignatureNotValid}
 import com.gu.pandomainauth.service.CryptoConf.{Signing, Verification}
 
+import java.time.Instant
 import scala.util.Try
 
 object CookieUtils {
@@ -23,7 +24,7 @@ object CookieUtils {
       authUser.user.avatarUrl.map(a => s"&avatarUrl=$a").getOrElse("") +
       s"&system=${authUser.authenticatingSystem}" +
       s"&authedIn=${authUser.authenticatedIn.mkString(",")}" +
-      s"&expires=${authUser.expires}" +
+      s"&expires=${authUser.expires.toEpochMilli}" +
       s"&multifactor=${authUser.multiFactor}"
 
   private[service] def deserializeAuthenticatedUser(serializedForm: String): Option[AuthenticatedUser] = {
@@ -45,7 +46,7 @@ object CookieUtils {
       user = User(firstName, lastName, email, data.get("avatarUrl")),
       authenticatingSystem = system,
       authenticatedIn = Set(authedIn.split(",").toSeq :_*),
-      expires = expires,
+      expires = Instant.ofEpochMilli(expires),
       multiFactor = multiFactor
     )
   }

--- a/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/service/CookieUtilsTest.scala
+++ b/pan-domain-auth-verification/src/test/scala/com/gu/pandomainauth/service/CookieUtilsTest.scala
@@ -3,19 +3,28 @@ package com.gu.pandomainauth.service
 import com.gu.pandomainauth.model.{AuthenticatedUser, User}
 import com.gu.pandomainauth.service.CookieUtils.CookieIntegrityFailure.{MalformedCookieText, SignatureNotValid}
 import com.gu.pandomainauth.service.CookieUtils.{deserializeAuthenticatedUser, parseCookieData, serializeAuthenticatedUser}
-import com.gu.pandomainauth.service.CryptoConf.{OnlyVerification, Signing}
+import com.gu.pandomainauth.service.CryptoConf.OnlyVerification
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{EitherValues, OptionValues}
 
-import java.security.PrivateKey
-import java.util.Date
+import java.time.Instant.now
+import java.time.temporal.ChronoUnit.MILLIS
 
 
 class CookieUtilsTest extends AnyFreeSpec with Matchers with EitherValues with OptionValues {
   import TestKeys._
 
-  val authUser = AuthenticatedUser(User("test", "üsér", "test.user@example.com", None), "testsuite", Set("testsuite", "another"), new Date().getTime + 86400, multiFactor = true)
+  val authUser = AuthenticatedUser(
+    User("test", "üsér", "test.user@example.com", None),
+    "testsuite",
+    Set("testsuite",
+      "another"),
+    // The expiry is serialised to millisecond accuracy
+    // so this needs to be at the same precision for comparison.
+    now().plusMillis(86400).truncatedTo(MILLIS),
+    multiFactor = true
+  )
 
   "generateCookieData" - {
     "generates a base64-encoded 'data.signature' cookie value" in {


### PR DESCRIPTION
This changes extracts part of https://github.com/guardian/pan-domain-authentication/pull/185: it takes the parts that strongly-type the time fields to use the `java.time` classes `Instant` & `Duration`, while leaving the grace-period-related parts for that other PR.

Note that some consuming code in [several apps](https://github.com/search?q=org%3Aguardian+%22apiGracePeriod+%3D%22+NOT+repo%3Aguardian%2Fpan-domain-authentication&type=code) will need to be updated to reflect the new `Instant` type of `apiGracePeriod`.

### The time-unit of the `expires` field... _milliseconds_ or _seconds_ since the epoch?

`expires` is a field in two places:

* the serialised, Base64-encoded value in Panda's `gutoolsAuth-assym` cookie
* the field on the [`AuthenticatedUser`](https://github.com/guardian/pan-domain-authentication/blob/fb75c04bb7436faae1f71f93ebd7532a39ea8a51/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/model/AuthenticatedUser.scala#L5) case class - where it was represented by a `Long`

It's actually in **milliseconds**, but it was treated [inconsistently](https://github.com/guardian/pan-domain-authentication/pull/187/files#r2003779712) as _seconds_ in Panda's test suite.

We can be certain that `expires` is in milliseconds for these two reasons:

1. Examining a real `gutoolsAuth-assym` cookie and Base64-decoding it, we get a payload like this:
    > firstName=Roberto&lastName=Tyley&...&**expires=1742386198000**&multifactor=true
    
    The value `expires=1742386198000` only [makes sense](https://www.epochconverter.com/) if it's in _milliseconds_ :
    ![image](https://github.com/user-attachments/assets/9b733238-45e0-44cc-9131-6911cb90bcba)
1.  The current code for determining `isExpired` compares `expired` to [`new Date().getTime`](https://docs.oracle.com/javase/8/docs/api/java/util/Date.html#getTime--):
    https://github.com/guardian/pan-domain-authentication/blob/3b00ea4d92a95b8d4eda718cf01d1c3a1fa696b5/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/model/AuthenticatedUser.scala#L7
    `new Date().getTime` returns _"the number of **milliseconds** since January 1, 1970, 00:00:00 GMT"_


## See also

* https://github.com/guardian/pan-domain-authentication/pull/188