### PR TITLE
Update GitHub codeowners to the workflow-and-collaboration team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @guardian/digital-cms
+* @guardian/workflow-and-collaboration


### PR DESCRIPTION
It looks like @guardian/workflow-and-collaboration are the right team for ownership of the pan-domain-authentication library? As well as authentication feeling like quite a key thing to both workflow and collaboration, the Panda service depends on the Panda settings files, which live in an S3 bucket in the AWS Workflow account!
