### PR TITLE
Upgrade AWS SDK from v1 to v2

### DIFF
--- a/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/PanDomainAuthSettingsRefresher.scala
+++ b/pan-domain-auth-core/src/main/scala/com/gu/pandomainauth/PanDomainAuthSettingsRefresher.scala
@@ -1,6 +1,6 @@
 package com.gu.pandomainauth
 
-import com.amazonaws.services.s3.AmazonS3
+import software.amazon.awssdk.services.s3.S3Client
 import com.gu.pandomainauth.model.PanDomainAuthSettings
 
 import java.util.concurrent.Executors.newScheduledThreadPool
@@ -28,9 +28,9 @@ class PanDomainAuthSettingsRefresher(
     system: String,
     bucketName: String,
     settingsFileKey: String,
-    s3Client: AmazonS3,
+    s3Client: S3Client,
     scheduler: ScheduledExecutorService = newScheduledThreadPool(1)
-  ) = this(domain, system, S3BucketLoader.forAwsSdkV1(s3Client, bucketName), settingsFileKey, scheduler)
+  ) = this(domain, system, S3BucketLoader.forAwsSdkV2(s3Client, bucketName), settingsFileKey, scheduler)
 
   private val settingsRefresher = new Settings.Refresher[PanDomainAuthSettings](
     new Settings.Loader(s3BucketLoader, settingsFileKey),

--- a/pan-domain-auth-example/app/VerifyExample.scala
+++ b/pan-domain-auth-example/app/VerifyExample.scala
@@ -1,24 +1,25 @@
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
-import com.amazonaws.regions.Regions
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
-import com.gu.pandomainauth.S3BucketLoader.forAwsSdkV1
+import software.amazon.awssdk.regions.Region
+import com.gu.pandomainauth.S3BucketLoader.forAwsSdkV2
 import com.gu.pandomainauth.model.{Authenticated, AuthenticatedUser, GracePeriod}
 import com.gu.pandomainauth.service.CryptoConf
 import com.gu.pandomainauth.{PanDomain, PublicSettings, Settings}
 
 import java.time.Duration
+import software.amazon.awssdk.services.s3.S3Client
 
 object VerifyExample {
   // Change this to point to the S3 bucket and key for the settings file
   val settingsFileKey = "local.dev-gutools.co.uk.settings.public"
   val bucketName = "pan-domain-auth-settings"
 
-  val region = Regions.EU_WEST_1
+  val region = Region.EU_WEST_1
   // Customise as appropriate depending on how you manage your AWS credentials
-  val credentials = DefaultAWSCredentialsProviderChain.getInstance()
-  val s3Client = AmazonS3ClientBuilder.standard().withRegion(region).withCredentials(credentials).build()
+  val s3Client = S3Client
+      .builder()
+      .region(region)
+      .build()
 
-  val loader = new Settings.Loader(forAwsSdkV1(s3Client, bucketName), settingsFileKey)
+  val loader = new Settings.Loader(forAwsSdkV2(s3Client, bucketName), settingsFileKey)
   val publicSettings = PublicSettings(loader)
 
   // Call the start method when your application starts up to ensure the settings are kept up to date

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PublicSettings.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/PublicSettings.scala
@@ -1,6 +1,6 @@
 package com.gu.pandomainauth
 
-import com.amazonaws.services.s3.AmazonS3
+import software.amazon.awssdk.services.s3.S3Client
 import com.gu.pandomainauth.Settings.{Loader, SettingsResult}
 import com.gu.pandomainauth.service.CryptoConf
 import com.gu.pandomainauth.service.CryptoConf.Verification
@@ -17,9 +17,9 @@ import java.util.concurrent.{Executors, ScheduledExecutorService}
  */
 class PublicSettings(loader: Settings.Loader, scheduler: ScheduledExecutorService) {
 
-  def this(settingsFileKey: String, bucketName: String, s3Client: AmazonS3,
+  def this(settingsFileKey: String, bucketName: String, s3Client: S3Client,
     scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(1)) = this(
-    new Settings.Loader(S3BucketLoader.forAwsSdkV1(s3Client, bucketName), settingsFileKey), scheduler
+    new Settings.Loader(S3BucketLoader.forAwsSdkV2(s3Client, bucketName), settingsFileKey), scheduler
   )
 
   private val settingsRefresher = new Settings.Refresher[Verification](

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/S3BucketLoader.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/S3BucketLoader.scala
@@ -1,8 +1,9 @@
 package com.gu.pandomainauth
 
-import com.amazonaws.services.s3.AmazonS3
+import software.amazon.awssdk.services.s3.S3Client
 
 import java.io.InputStream
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
 
 /**
  * This trait provides a way to download a file from an S3 bucket, in a way that's agnostic of which
@@ -20,6 +21,8 @@ object S3BucketLoader {
    * A convenience method to create an S3BucketLoader using AWS SDK v1, the version used by most of our existing code.
    * However, codebases that want to use AWS SDK v2 are able to provide their own implementation of S3BucketLoader.
    */
-  def forAwsSdkV1(s3Client: AmazonS3, bucketName: String): S3BucketLoader =
-    s3Client.getObject(bucketName, _).getObjectContent
+  def forAwsSdkV2(s3Client: S3Client, bucketName: String): S3BucketLoader =
+    (key: String) => 
+          s3Client.getObject(
+            GetObjectRequest.builder().bucket(bucketName).key(key).build())
 }

--- a/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/Settings.scala
+++ b/pan-domain-auth-verification/src/main/scala/com/gu/pandomainauth/Settings.scala
@@ -1,6 +1,6 @@
 package com.gu.pandomainauth
 
-import com.amazonaws.util.IOUtils
+import software.amazon.awssdk.utils.IoUtils
 import com.gu.pandomainauth.service.CryptoConf
 import com.gu.pandomainauth.service.CryptoConf.Verification
 import org.slf4j.{Logger, LoggerFactory}
@@ -68,7 +68,7 @@ object Settings {
     def loadAndParseSettingsMap(): SettingsResult[Map[String, String]] = fetchSettings().flatMap(extractSettings)
 
     private def fetchSettings(): SettingsResult[String] = try {
-      Right(IOUtils.toString(s3BucketLoader.inputStreamFetching(settingsFileKey)))
+      Right(IoUtils.toUtf8String(s3BucketLoader.inputStreamFetching(settingsFileKey)))
     } catch { case NonFatal(e) => Left(SettingsDownloadFailure(e)) }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
 
-  val awsDependencies = Seq("com.amazonaws" % "aws-java-sdk-s3" % "1.12.772")
+  val awsDependencies = Seq("software.amazon.awssdk" % "s3" % "2.33.6")
 
   case class PlayVersion(
     majorVersion: Int,


### PR DESCRIPTION
### What does this change?

Paired with @SHession on this work.

AWS SDK for Java v1 will be EOL on 31st December 2025.  It has been in Maintenance mode since [31st July 2024](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/). 

The pull request upgrades its AWS SDK to the latest v2 version.

In addition, we supplied a default implementation for `S3BucketLoader` using AWS SDK v1 previously.  With this AWS upgrade, we switch the supplied implementation to v2 and rename the factory method to `forAwsSdkV2`.

For this reason, applications may need to have code change if they call the old method `forAwsSdkV1`.  They may need to implement their own `S3BucketLoader` if they want to avoid pulling in AWS SDK v2.

### How to test?

We published a preview release to maven repository.  We drafted pull requests to bump the [login.gutools](https://github.com/guardian/login.gutools/pull/102) and [s3 upload ](https://github.com/guardian/s3-upload/pull/72)to this preview version of pan-domain.

We tested this branch of login.gutools and s3 uploader locally and also on CODE.
- on Incognito window, the browser was redirected to Google login when opening S3 uploader
- S3 uploader opened successfully after Google login
- S3 uploaded could open in another tab without login again

We also generated the dependency tree using `sbt dependencyTree` to make sure that no AWS SDK v1 was pulled in any more.