### PR TITLE
Add Jackson libraries as dependencies to evict vulnerable dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ def directSubfolderProject(path: String): Project = Project(path, file(path)).se
 lazy val panDomainAuthVerification = directSubfolderProject("pan-domain-auth-verification")
   .settings(
     artifactProductionSettings,
-    libraryDependencies ++= cryptoDependencies ++ awsDependencies ++ loggingDependencies
+    libraryDependencies ++= cryptoDependencies ++ awsDependencies ++ loggingDependencies ++ jacksonDependencies
   )
 
 lazy val panDomainAuthCore = directSubfolderProject("pan-domain-auth-core")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,8 +17,8 @@ object Dependencies {
   }
 
   object PlayVersion {
-    val V29 = PlayVersion(2, 9, "com.typesafe.play", "2.9.6")
-    val V30 = PlayVersion(3, 0, "org.playframework", "3.0.6")
+    val V29 = PlayVersion(2, 9, "com.typesafe.play", "2.9.9")
+    val V30 = PlayVersion(3, 0, "org.playframework", "3.0.9")
   }
 
   val hmacHeaders = "com.gu" %% "hmac-headers" % "2.0.1"
@@ -41,6 +41,7 @@ object Dependencies {
 
   val jacksonVersion = "2.20.0"
 
+  // A transient dependency added to evict vulnerable Jackson versions
   val jacksonDependencies = Seq(
     "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
     "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,4 +39,16 @@ object Dependencies {
 
   val loggingDependencies = Seq("org.slf4j" % "slf4j-api" % "1.7.36")
 
+  val jacksonVersion = "2.20.0"
+
+  val jacksonDependencies = Seq(
+    "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
+    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
+    "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,
+    "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
+    "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % jacksonVersion,
+    "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
+  )
+
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.6")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.9")
 
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 


### PR DESCRIPTION
## Description
This PR is intended to fix the vulnerable Jackson dependencies reported by Dependabot: https://github.com/guardian/pan-domain-authentication/security/dependabot/60

## Testing
Tested the preview version using https://github.com/guardian/login.gutools/pull/104 locally. 