### PR TITLE
Upgrade the amazon sdk version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
 
-  val awsDependencies = Seq("software.amazon.awssdk" % "s3" % "2.42.25")
+  val awsDependencies = Seq("software.amazon.awssdk" % "s3" % "2.44.9")
 
   case class PlayVersion(
     majorVersion: Int,


### PR DESCRIPTION
@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->
This upgrades the to the latest aws sdk version