### PR TITLE
Upgrade amazon sdk

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
 
-  val awsDependencies = Seq("software.amazon.awssdk" % "s3" % "2.44.9")
+  val awsDependencies = Seq("software.amazon.awssdk" % "s3" % "2.46.7")
 
   case class PlayVersion(
     majorVersion: Int,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,3 +4,5 @@ addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.10")
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")
+
+addDependencyTreePlugin


### PR DESCRIPTION
@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->

This upgrades the version of the amazon sdk to patch a netty vulnerability