### PR TITLE
Upgrade Jackson version to 2.21.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -39,7 +39,7 @@ object Dependencies {
 
   val loggingDependencies = Seq("org.slf4j" % "slf4j-api" % "1.7.36")
 
-  val jacksonVersion = "2.21.1"
+  val jacksonVersion = "2.21.4"
 
   // A transient dependency added to evict vulnerable Jackson versions
   val jacksonDependencies = Seq(


### PR DESCRIPTION
Patching Jackson version in response to Dependabot vulnerability alert.

@guardian/digital-cms
<!-- Please include the Editorial Tools Team in PRs especially if it is a major change. We rely on this library for log in across all our tools. Thank you. -->